### PR TITLE
feat(anthropic): upstream parity for claude-4.6, adaptive thinking, s…

### DIFF
--- a/Sources/AnthropicProvider/AnthropicMessagesAPI.swift
+++ b/Sources/AnthropicProvider/AnthropicMessagesAPI.swift
@@ -105,6 +105,7 @@ public struct AnthropicResponseContextManagement: Codable, Sendable {
     public enum AppliedEdit: Codable, Sendable {
         case clearToolUses20250919(ClearToolUses20250919)
         case clearThinking20251015(ClearThinking20251015)
+        case compact20260112(Compact20260112)
 
         enum CodingKeys: String, CodingKey {
             case type
@@ -113,6 +114,7 @@ public struct AnthropicResponseContextManagement: Codable, Sendable {
         enum EditType: String {
             case clearToolUses20250919 = "clear_tool_uses_20250919"
             case clearThinking20251015 = "clear_thinking_20251015"
+            case compact20260112 = "compact_20260112"
         }
 
         public init(from decoder: Decoder) throws {
@@ -132,6 +134,8 @@ public struct AnthropicResponseContextManagement: Codable, Sendable {
                 self = .clearToolUses20250919(try single.decode(ClearToolUses20250919.self))
             case .clearThinking20251015:
                 self = .clearThinking20251015(try single.decode(ClearThinking20251015.self))
+            case .compact20260112:
+                self = .compact20260112(try single.decode(Compact20260112.self))
             }
         }
 
@@ -140,6 +144,8 @@ public struct AnthropicResponseContextManagement: Codable, Sendable {
             case .clearToolUses20250919(let value):
                 try value.encode(to: encoder)
             case .clearThinking20251015(let value):
+                try value.encode(to: encoder)
+            case .compact20260112(let value):
                 try value.encode(to: encoder)
             }
         }
@@ -167,6 +173,10 @@ public struct AnthropicResponseContextManagement: Codable, Sendable {
             case clearedThinkingTurns = "cleared_thinking_turns"
             case clearedInputTokens = "cleared_input_tokens"
         }
+    }
+
+    public struct Compact20260112: Codable, Sendable {
+        public let type: String
     }
 
     public let appliedEdits: [AppliedEdit]


### PR DESCRIPTION
…peed, compact edit

## Description

Ports several features from the upstream Vercel AI SDK TypeScript implementation to achieve parity, centered around claude-4.6 model support and related new capabilities.

- **Adaptive thinking**: new `thinking.type = 'adaptive'` mode — sends `{type:'adaptive'}` with no `budget_tokens`, suppresses temperature/topP/topK like manual thinking mode
- **Speed (fast mode)**: new `AnthropicSpeed` type (`fast`/`standard`); `fast` adds `fast-mode-2026-02-01` beta header (Opus 4.6 only)
- **Effort max**: added `max` case to `AnthropicEffort` enum
- **Compact context edit**: new `compact_20260112` context management edit type with optional `trigger`, `pauseAfterCompaction`, and `instructions`; adds `compact-2026-01-12` beta alongside existing `context-management-2025-06-27`
- **Response decoding**: `AnthropicResponseContextManagement` now decodes `compact_20260112` applied edits without throwing
- **claude-sonnet-4-6 / claude-opus-4-6**: added to model ID list and `getModelCapabilities` with 128K max output tokens and native structured output support

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

- Upstream file(s): `packages/anthropic/src/anthropic-messages-language-model.ts`, `packages/anthropic/src/anthropic-messages-options.ts`, `packages/anthropic/src/anthropic-messages-api.ts`
- Upstream commit: https://github.com/vercel/ai/tree/main/packages/anthropic

## Testing

- [x] All tests pass (`swift test`)
- [x] Added tests for new functionality
- [x] Verified upstream parity (if applicable)