### PR TITLE
fix: execute tool handlers concurrently in stream loop

### DIFF
--- a/Sources/SwiftAISDK/GenerateText/StreamTextActor.swift
+++ b/Sources/SwiftAISDK/GenerateText/StreamTextActor.swift
@@ -59,6 +59,7 @@ actor StreamTextActor {
     }
 
     private var pendingApprovals: [PendingApproval] = []
+    private var inFlightToolTasks: [String: Task<Void, Never>] = [:]
 
     private let totalUsagePromise: DelayedPromise<LanguageModelUsage>
     private let finishReasonPromise: DelayedPromise<FinishReason>
@@ -448,7 +449,10 @@ actor StreamTextActor {
                 if Task.isCancelled { break }
                 switch decision {
                 case .approve:
-                    await executeToolAfterApproval(pending)
+                    // Execute concurrently so multiple approved tools run in parallel
+                    inFlightToolTasks[pending.toolCallId] = Task { [weak self] in
+                        await self?.executeToolAfterApproval(pending)
+                    }
                 case .deny:
                     await emitToolOutputDenied(callId: pending.toolCallId, toolName: pending.toolName)
                 }
@@ -523,6 +527,7 @@ actor StreamTextActor {
         openReasoningIds.removeAll()
         activeToolInputs.removeAll()
         activeToolNames.removeAll()
+        inFlightToolTasks.removeAll()
         capturedResponseId = configuration.generateId()
         capturedModelId = model.modelId
         capturedTimestamp = configuration.currentDate()
@@ -959,7 +964,10 @@ case let .toolInputStart(id, toolName, providerMetadata, providerExecuted, dynam
                         tool: tool,
                         providerMetadata: typed.providerMetadata
                     )
-                    await executeToolAfterApproval(pending)
+                    // Execute concurrently so the stream loop can continue reading subsequent tool calls
+                    inFlightToolTasks[typed.toolCallId] = Task { [weak self] in
+                        await self?.executeToolAfterApproval(pending)
+                    }
                 }
 
             case .toolApprovalRequest(let request):
@@ -1091,6 +1099,14 @@ case let .toolInputStart(id, toolName, providerMetadata, providerExecuted, dynam
                 openReasoningIds.removeAll()
                 finalizePendingContent()
                 await resolvePendingApprovals()
+
+                // Wait for all concurrently-executing tool handlers to complete before finalizing the step.
+                // This includes tasks spawned in the stream loop and by resolvePendingApprovals
+                for (_, task) in inFlightToolTasks {
+                    await task.value
+                }
+                inFlightToolTasks.removeAll()
+
                 let response = LanguageModelResponseMetadata(
                     id: capturedResponseId ?? configuration.generateId(),
                     timestamp: capturedTimestamp ?? configuration.currentDate(),

--- a/Tests/SwiftAISDKTests/GenerateText/StreamTextConcurrencyTests.swift
+++ b/Tests/SwiftAISDKTests/GenerateText/StreamTextConcurrencyTests.swift
@@ -92,4 +92,93 @@ struct StreamTextConcurrencyTests {
         let idxFinish = partsCollected.firstIndex { if case .finish = $0 { return true } else { return false } }
         #expect(idxAbort != nil && idxFinish != nil && idxAbort! < idxFinish!)
     }
+
+    actor EventLog {
+        private(set) var events: [String] = []
+        func record(_ event: String) { events.append(event) }
+    }
+
+    @Test("two tool calls in one response execute concurrently, not sequentially",
+          .timeLimit(.minutes(1)))
+    func twoToolCallsExecuteConcurrently() async throws {
+        let log = EventLog()
+
+        // Provider stream emits two toolCalls before .finish — mimics a model
+        // requesting parallel tool use in one response
+        let parts: [LanguageModelV3StreamPart] = [
+            .streamStart(warnings: []),
+            .responseMetadata(id: "step-1", modelId: "mock-model", timestamp: Date(timeIntervalSince1970: 0)),
+            .toolCall(LanguageModelV3ToolCall(
+                toolCallId: "call-A",
+                toolName: "slow_tool",
+                input: "{\"id\":\"A\"}",
+                providerExecuted: false,
+                providerMetadata: nil
+            )),
+            .toolCall(LanguageModelV3ToolCall(
+                toolCallId: "call-B",
+                toolName: "slow_tool",
+                input: "{\"id\":\"B\"}",
+                providerExecuted: false,
+                providerMetadata: nil
+            )),
+            .finish(
+                finishReason: LanguageModelV3FinishReason(unified: .toolCalls),
+                usage: defaultUsage,
+                providerMetadata: nil
+            ),
+        ]
+
+        let stream = AsyncThrowingStream<LanguageModelV3StreamPart, Error> { c in
+            for p in parts { c.yield(p) }
+            c.finish()
+        }
+
+        let model = MockLanguageModelV3(doStream: .singleValue(LanguageModelV3StreamResult(stream: stream)))
+
+        let tools: ToolSet = [
+            "slow_tool": Tool(
+                description: "Sleeps then returns",
+                inputSchema: FlexibleSchema(jsonSchema(.object([
+                    "type": .string("object"),
+                    "properties": .object(["id": .object(["type": .string("string")])]),
+                    "required": .array([.string("id")])
+                ]))),
+                needsApproval: .never,
+                execute: { input, _ in
+                    let id: String
+                    if case .object(let obj) = input, case .string(let s) = obj["id"] {
+                        id = s
+                    } else {
+                        id = "unknown"
+                    }
+                    await log.record("start-\(id)")
+                    try await Task.sleep(for: .seconds(1))
+                    await log.record("end-\(id)")
+                    return .value(.object(["id": .string(id), "done": .bool(true)]))
+                }
+            )
+        ]
+
+        let result: DefaultStreamTextResult<JSONValue, JSONValue> = try streamText(
+            model: .v3(model),
+            prompt: "hello",
+            tools: tools
+        )
+
+        _ = try await result.collectFullStream()
+
+        // If concurrent: [start-A, start-B, end-A, end-B] (both starts before any end)
+        // If sequential: [start-A, end-A, start-B, end-B] (an end appears before the second start)
+        let events = await log.events
+        let starts = events.filter { $0.hasPrefix("start-") }
+        let firstEnd = events.firstIndex { $0.hasPrefix("end-") }
+        let lastStart = events.lastIndex { $0.hasPrefix("start-") }
+
+        #expect(starts.count == 2, "Expected 2 starts, got \(starts.count). Events: \(events)")
+        #expect(
+            lastStart! < firstEnd!,
+            "Tool calls ran sequentially — an end arrived before both starts. Events: \(events)"
+        )
+    }
 }


### PR DESCRIPTION
## Description

When the LLM emits multiple `tool_use` blocks in a single response, `executeToolAfterApproval` was awaited synchronously inside the `consumeProviderStream` loop. This blocked the loop, preventing subsequent tool calls from being read until the first completed.

The fix is to spawn each tool execution in a concurrent Task and drain all in-flight tasks at the step boundary before finalizing. This allows parallel tool execution while preserving step semantics.

Includes a regression test that emits two tool calls in one stream response with 1-second sleep handlers and asserts the execution windows overlap.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Testing

- [X] All tests pass (`swift test`)
- [X] Added tests for new functionality

## Checklist

- [X] Code follows the project's style guidelines
- [X] Added/updated documentation as needed
- [X] No breaking changes (or documented in CHANGELOG)