### PR TITLE
fix: avoid tool result JSON serialization crashes

### DIFF
--- a/Sources/OpenAIProvider/Chat/OpenAIChatPrompt.swift
+++ b/Sources/OpenAIProvider/Chat/OpenAIChatPrompt.swift
@@ -222,18 +222,7 @@ struct OpenAIChatMessagesConverter {
     }
 
     private static func encodeJSONValue(_ value: JSONValue) throws -> String {
-        func toAny(_ value: JSONValue) -> Any {
-            switch value {
-            case .null: return NSNull()
-            case .bool(let bool): return bool
-            case .number(let number): return number
-            case .string(let string): return string
-            case .array(let array): return array.map { toAny($0) }
-            case .object(let object): return object.mapValues { toAny($0) }
-            }
-        }
-
-        let data = try JSONSerialization.data(withJSONObject: toAny(value), options: [])
+        let data = try JSONEncoder().encode(value)
         guard let string = String(data: data, encoding: .utf8) else {
             throw UnsupportedFunctionalityError(functionality: "Unable to encode JSON value")
         }

--- a/Sources/SwiftAISDK/GenerateText/ToResponseMessages.swift
+++ b/Sources/SwiftAISDK/GenerateText/ToResponseMessages.swift
@@ -50,7 +50,7 @@ public func toResponseMessages(
         case .toolResult(let result, _):
             guard result.providerExecuted != true else { return nil }
             let output = createToolModelOutput(
-                output: jsonValueToAny(result.output),
+                output: result.output,
                 tool: tools?[result.toolName],
                 errorMode: .none
             )
@@ -128,7 +128,7 @@ private func assistantContentPart(
     case .toolResult(let result, let providerMetadata):
         guard result.providerExecuted == true else { return nil }
         let output = createToolModelOutput(
-            output: jsonValueToAny(result.output),
+            output: result.output,
             tool: tools?[result.toolName],
             errorMode: .none
         )
@@ -165,26 +165,5 @@ private func assistantContentPart(
 
     case .source:
         return nil
-    }
-}
-
-private func jsonValueToAny(_ value: JSONValue) -> Any {
-    switch value {
-    case .string(let string):
-        return string
-    case .number(let number):
-        return number
-    case .bool(let bool):
-        return bool
-    case .null:
-        return NSNull()
-    case .array(let array):
-        return array.map { jsonValueToAny($0) }
-    case .object(let dictionary):
-        var result: [String: Any] = [:]
-        for (key, entry) in dictionary {
-            result[key] = jsonValueToAny(entry)
-        }
-        return result
     }
 }

--- a/Sources/SwiftAISDK/Prompt/CreateToolModelOutput.swift
+++ b/Sources/SwiftAISDK/Prompt/CreateToolModelOutput.swift
@@ -115,6 +115,11 @@ private func toJSONValue(_ value: Any?) -> JSONValue {
         return jsonValue
     }
 
+    // Preserve Foundation nulls from JSONValue → Any roundtrips.
+    if value is NSNull {
+        return .null
+    }
+
     // Handle basic types
     if let string = value as? String {
         return .string(string)
@@ -136,13 +141,16 @@ private func toJSONValue(_ value: Any?) -> JSONValue {
     }
 
     // Fallback: try JSON serialization
-    do {
-        let data = try JSONSerialization.data(withJSONObject: value, options: [])
-        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
-        return decoded
-    } catch {
-        // If all else fails, convert to string and wrap in JSONValue
-        return .string(String(describing: value))
+    if JSONSerialization.isValidJSONObject(value) {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: value, options: [])
+            let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+            return decoded
+        } catch {
+            // Fall through to string conversion below.
+        }
     }
-}
 
+    // If all else fails, convert to string and wrap in JSONValue.
+    return .string(String(describing: value))
+}


### PR DESCRIPTION
Use JSONEncoder for OpenAI chat tool-result JSON encoding, preserve NSNull handling in CreateToolModelOutput, and avoid round-tripping tool outputs through Any in ToResponseMessages.