### PR TITLE
fix(openai): use correct snake_case container_id key

### DIFF
--- a/Sources/OpenAIProvider/OpenAIResponsesModel.swift
+++ b/Sources/OpenAIProvider/OpenAIResponsesModel.swift
@@ -1010,7 +1010,7 @@ public final class OpenAIResponsesLanguageModel: LanguageModelV3 {
                     continue
                 }
                 var inputPayload: [String: JSONValue] = [
-                    "containerId": .string(containerId)
+                    "container_id": .string(containerId)
                 ]
                 if let code = object["code"] {
                     inputPayload["code"] = code
@@ -1541,7 +1541,7 @@ public final class OpenAIResponsesLanguageModel: LanguageModelV3 {
                 dynamic: nil,
                 title: nil
             ))
-            let initial = "{\"containerId\":\"\(containerId)\",\"code\":\""
+            let initial = "{\"container_id\":\"\(containerId)\",\"code\":\""
             continuation.yield(.toolInputDelta(id: callId, delta: initial, providerMetadata: nil))
         case "apply_patch_call":
             guard let callId = item["call_id"]?.stringValue,
@@ -2133,7 +2133,7 @@ public final class OpenAIResponsesLanguageModel: LanguageModelV3 {
 
         let inputValue: JSONValue = .object([
             "code": .string(code),
-            "containerId": .string(interpreter.containerId)
+            "container_id": .string(interpreter.containerId)
         ])
         do {
             let inputString = try jsonString(from: inputValue)

--- a/Tests/SwiftAISDKTests/OpenAI/OpenAIResponsesLanguageModelTests.swift
+++ b/Tests/SwiftAISDKTests/OpenAI/OpenAIResponsesLanguageModelTests.swift
@@ -2926,7 +2926,7 @@ struct OpenAIResponsesLanguageModelTests {
 
         #expect(parts.contains { part in
             if case .toolInputDelta(let id, let delta, _) = part {
-                return id == "code_call" && delta.hasPrefix("{\"containerId\":\"container-7\",\"code\":\"")
+                return id == "code_call" && delta.hasPrefix("{\"container_id\":\"container-7\",\"code\":\"")
             }
             return false
         })


### PR DESCRIPTION
## Description

In code interpreter tool inputs, the tool call input JSON was using camelCase "containerId" but the OpenAICodeInterpreterInput Codable struct expects snake_case "container_id" via CodingKeys, causing deserialization failures when using the code interpreter tool.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

<!-- If this is an upstream port, link to the TypeScript source -->

- Upstream file(s):
- Upstream commit:

## Testing

- [ x] All tests pass (`swift test`)
- [ ] Added tests for new functionality
- [ ] Verified upstream parity (if applicable)

## Checklist

- [ x] Code follows the project's style guidelines
- [ ] Added/updated documentation as needed
- [ ] Added upstream reference in file headers (if applicable)
- [ ] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)

## Additional Notes

<!-- Any additional information -->
