### PR TITLE
Fix EventSourceParser silently dropping Data chunks that split multi-…

### DIFF
--- a/Sources/EventSourceParser/Parser.swift
+++ b/Sources/EventSourceParser/Parser.swift
@@ -10,13 +10,76 @@ public final class EventSourceParser: @unchecked Sendable {
     private var eventType: String = ""
     private var prevTrailingCR: Bool = false
 
+    /// Leftover bytes from a previous chunk that ended mid-UTF-8 sequence
+    private var pendingBytes = Data()
+
     public init(callbacks: ParserCallbacks) {
         self.callbacks = callbacks
     }
 
     public func feed(_ chunkData: Data) {
-        guard let s = String(data: chunkData, encoding: .utf8) else { return }
-        feed(s)
+        // Prepend any leftover bytes from a previous chunk that split a
+        // multi-byte UTF-8 character at an arbitrary Data boundary
+        var bytes: Data
+        if pendingBytes.isEmpty {
+            bytes = chunkData
+        } else {
+            bytes = pendingBytes
+            bytes.append(chunkData)
+            pendingBytes.removeAll(keepingCapacity: true)
+        }
+
+        // Try the fast path first
+        if let s = String(data: bytes, encoding: .utf8) {
+            feed(s)
+            return
+        }
+
+        // Conversion failed -- likely an incomplete UTF-8 sequence at the
+        // end of the buffer. Trim trailing continuation bytes and decode
+        // the valid prefix so we don't silently drop the entire chunk.
+        let splitIndex = Self.utf8SafeSplitIndex(bytes)
+        if splitIndex > 0, let s = String(data: bytes.prefix(splitIndex), encoding: .utf8) {
+            pendingBytes = Data(bytes.suffix(from: splitIndex))
+            feed(s)
+        } else {
+            // Entire chunk is unusable (e.g. all continuation bytes).
+            // Carry everything forward in case the next chunk completes it.
+            pendingBytes = bytes
+        }
+    }
+
+    /// Finds the largest prefix length of `data` that ends on a complete
+    /// UTF-8 character boundary. Scans backwards from the end (at most 3
+    /// bytes) to find the start of the trailing multi-byte sequence and
+    /// checks whether enough continuation bytes are present.
+    private static func utf8SafeSplitIndex(_ data: Data) -> Int {
+        let count = data.count
+        guard count > 0 else { return 0 }
+
+        // ASCII -- boundary is already safe
+        if data[count - 1] < 0x80 { return count }
+
+        // Walk backwards over continuation bytes (10xxxxxx) to find the
+        // lead byte. UTF-8 sequences are at most 4 bytes, so we check
+        // at most 3 bytes back.
+        var i = count - 1
+        let limit = max(0, count - 4)
+        while i > limit && data[i] & 0xC0 == 0x80 { i -= 1 }
+
+        let leadByte = data[i]
+        let expectedLength: Int
+        if leadByte & 0x80 == 0 { expectedLength = 1 }
+        else if leadByte & 0xE0 == 0xC0 { expectedLength = 2 }
+        else if leadByte & 0xF0 == 0xE0 { expectedLength = 3 }
+        else if leadByte & 0xF8 == 0xF0 { expectedLength = 4 }
+        else { return count } // Invalid lead byte -- let the caller handle it
+
+        let available = count - i
+        if available >= expectedLength {
+            return count // Complete sequence at the tail
+        }
+        return i // Split before the incomplete sequence
     }
 
     public func feed(_ newChunk: String) {
@@ -74,6 +137,7 @@ public final class EventSourceParser: @unchecked Sendable {
         eventType = ""
         incompleteLine = ""
         prevTrailingCR = false
+        pendingBytes.removeAll(keepingCapacity: true)
     }
 
     private func parseLine(_ line: String) {

--- a/Tests/EventSourceParserTests/ParserTests.swift
+++ b/Tests/EventSourceParserTests/ParserTests.swift
@@ -296,3 +296,215 @@ private final class Collector {
     p.feed("{\"error\":\"Internal\"}\n")
     #expect(!c.errors.isEmpty)
 }
+
+// MARK: - feed(Data) UTF-8 chunk boundary handling
+
+@Test func parser_feedData_asciiOnlyChunks() {
+    // Pure ASCII should always work regardless of split position
+    let event = "data: Hello World\n\n"
+    let bytes = Data(event.utf8)
+
+    // Split at every possible position
+    for splitPoint in 1..<bytes.count {
+        let c = Collector()
+        let p = EventSourceParser(callbacks: c.callbacks())
+        p.feed(Data(bytes.prefix(splitPoint)))
+        p.feed(Data(bytes.suffix(from: splitPoint)))
+        #expect(c.events.count == 1, "ASCII split at \(splitPoint) should produce 1 event")
+        #expect(c.events.first?.data == "Hello World")
+    }
+}
+
+@Test func parser_feedData_emptyChunks() {
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+
+    // Empty chunks before, between, and after real data
+    p.feed(Data())
+    p.feed(Data("data: ok\n\n".utf8))
+    p.feed(Data())
+
+    #expect(c.events.count == 1)
+    #expect(c.events.first?.data == "ok")
+}
+
+@Test func parser_feedData_split2ByteChar() {
+    // "é" is C3 A9 (2 bytes). Split after the lead byte.
+    let event = "data: café\n\n"
+    let bytes = Data(event.utf8)
+
+    let eAcuteUTF8 = Data([0xC3, 0xA9])
+    guard let range = bytes.firstRange(of: eAcuteUTF8) else {
+        Issue.record("Could not find é bytes")
+        return
+    }
+    let splitPoint = range.lowerBound + 1
+
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+    p.feed(Data(bytes.prefix(splitPoint)))
+    p.feed(Data(bytes.suffix(from: splitPoint)))
+
+    #expect(c.events.count == 1)
+    #expect(c.events.first?.data == "café")
+}
+
+@Test func parser_feedData_split3ByteChar() {
+    // "中" is E4 B8 AD (3 bytes). Test split at each internal position.
+    let event = "data: 中\n\n"
+    let bytes = Data(event.utf8)
+
+    let charUTF8 = Data([0xE4, 0xB8, 0xAD])
+    guard let range = bytes.firstRange(of: charUTF8) else {
+        Issue.record("Could not find 中 bytes")
+        return
+    }
+
+    // Split after 1 byte (E4 | B8 AD) and after 2 bytes (E4 B8 | AD)
+    for offset in 1...2 {
+        let splitPoint = range.lowerBound + offset
+        let c = Collector()
+        let p = EventSourceParser(callbacks: c.callbacks())
+        p.feed(Data(bytes.prefix(splitPoint)))
+        p.feed(Data(bytes.suffix(from: splitPoint)))
+        #expect(c.events.count == 1, "3-byte char split at offset \(offset) should produce 1 event")
+        #expect(c.events.first?.data == "中")
+    }
+}
+
+@Test func parser_feedData_split4ByteChar() {
+    // "😀" is F0 9F 98 80 (4 bytes). Test split at each internal position.
+    let event = "data: 😀\n\n"
+    let bytes = Data(event.utf8)
+
+    let charUTF8 = Data([0xF0, 0x9F, 0x98, 0x80])
+    guard let range = bytes.firstRange(of: charUTF8) else {
+        Issue.record("Could not find 😀 bytes")
+        return
+    }
+
+    for offset in 1...3 {
+        let splitPoint = range.lowerBound + offset
+        let c = Collector()
+        let p = EventSourceParser(callbacks: c.callbacks())
+        p.feed(Data(bytes.prefix(splitPoint)))
+        p.feed(Data(bytes.suffix(from: splitPoint)))
+        #expect(c.events.count == 1, "4-byte char split at offset \(offset) should produce 1 event")
+        #expect(c.events.first?.data == "😀")
+    }
+}
+
+@Test func parser_feedData_4ByteCharFedByteByByte() {
+    // Feed each byte of a 4-byte character as a separate Data chunk.
+    // pendingBytes must accumulate across all 4 calls.
+    let event = "data: X😀Y\n\n"
+    let bytes = Array(event.utf8)
+
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+    for byte in bytes {
+        p.feed(Data([byte]))
+    }
+
+    #expect(c.events.count == 1)
+    #expect(c.events.first?.data == "X😀Y")
+}
+
+@Test func parser_feedData_consecutiveMultibyteChars() {
+    // Two adjacent 4-byte emojis with the split falling between the
+    // trailing bytes of the first and the leading byte of the second
+    let event = "data: 🎉🎊\n\n"
+    let bytes = Data(event.utf8)
+
+    // 🎉 = F0 9F 8E 89, 🎊 = F0 9F 8E 8A
+    // Split inside the first emoji after 2 bytes
+    let firstEmoji = Data([0xF0, 0x9F, 0x8E, 0x89])
+    guard let range = bytes.firstRange(of: firstEmoji) else {
+        Issue.record("Could not find 🎉 bytes")
+        return
+    }
+    let splitPoint = range.lowerBound + 2
+
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+    p.feed(Data(bytes.prefix(splitPoint)))
+    p.feed(Data(bytes.suffix(from: splitPoint)))
+
+    #expect(c.events.count == 1)
+    #expect(c.events.first?.data == "🎉🎊")
+}
+
+@Test func parser_feedData_splitMultibyteCorruptsAdjacentEvents() {
+    // Simulates the real failure mode: a dropped chunk merges fragments
+    // of two different SSE events, producing garbled JSON
+    let event1 = "data: {\"type\":\"content_block_delta\",\"index\":0}\n\n"
+    let event2 = "data: {\"type\":\"thinking_delta\",\"thinking\":\"café résumé\"}\n\n"
+    let event3 = "data: {\"type\":\"content_block_stop\"}\n\n"
+
+    var allBytes = Data()
+    allBytes.append(Data(event1.utf8))
+    allBytes.append(Data(event2.utf8))
+    allBytes.append(Data(event3.utf8))
+
+    // "é" in "café" is C3 A9 in UTF-8 (2 bytes). Split inside it.
+    let eAcuteUTF8 = Data([0xC3, 0xA9])
+    guard let accentRange = allBytes.firstRange(of: eAcuteUTF8) else {
+        Issue.record("Could not find accented character bytes")
+        return
+    }
+    let splitPoint = accentRange.lowerBound + 1
+
+    let chunk1 = Data(allBytes.prefix(splitPoint))
+    let chunk2 = Data(allBytes.suffix(from: splitPoint))
+
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+    p.feed(chunk1)
+    p.feed(chunk2)
+
+    #expect(c.events.count == 3, "All events should survive a chunk split inside a multi-byte character")
+    #expect(c.events[0].data == "{\"type\":\"content_block_delta\",\"index\":0}")
+    #expect(c.events[1].data == "{\"type\":\"thinking_delta\",\"thinking\":\"café résumé\"}")
+    #expect(c.events[2].data == "{\"type\":\"content_block_stop\"}")
+}
+
+@Test func parser_feedData_resetClearsPendingBytes() {
+    // Feed an incomplete multi-byte sequence, then reset. The leftover
+    // bytes should be discarded so the next feed starts clean.
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+
+    // First byte of "é" (C3) without the continuation byte
+    p.feed(Data([0xC3]))
+    p.reset(consume: false)
+
+    // New event after reset should work normally
+    p.feed(Data("data: clean\n\n".utf8))
+    #expect(c.events.count == 1)
+    #expect(c.events.first?.data == "clean")
+}
+
+@Test func parser_feedData_multipleEventsSpanningManySplits() {
+    // 5 events with multi-byte content, fed in 3-byte micro-chunks
+    var fixture = ""
+    for i in 0..<5 {
+        fixture += "data: msg\(i) \u{00E9}\u{4E2D}\u{1F600}\n\n"
+    }
+    let bytes = Data(fixture.utf8)
+
+    let c = Collector()
+    let p = EventSourceParser(callbacks: c.callbacks())
+
+    let chunkSize = 3
+    var offset = 0
+    while offset < bytes.count {
+        let end = min(offset + chunkSize, bytes.count)
+        p.feed(Data(bytes[offset..<end]))
+        offset = end
+    }
+
+    #expect(c.events.count == 5)
+    for i in 0..<5 {
+        #expect(c.events[i].data == "msg\(i) \u{00E9}\u{4E2D}\u{1F600}")
+    }
+}

--- a/Tests/EventSourceParserTests/StreamTests.swift
+++ b/Tests/EventSourceParserTests/StreamTests.swift
@@ -63,3 +63,99 @@ import Foundation
     #expect(!captured.isEmpty)
     #expect(received.first?.data == "ok")
 }
+
+// MARK: - feed(Data) UTF-8 chunk boundary handling (end-to-end)
+
+@Test func eventSourceParserStream_asciiSplitChunks() async throws {
+    // ASCII data split into many small chunks should work fine
+    let event = "data: Hello World\n\n"
+    let bytes = Data(event.utf8)
+
+    // Yield one byte at a time
+    let input = AsyncThrowingStream<Data, Error> { continuation in
+        for byte in bytes {
+            continuation.yield(Data([byte]))
+        }
+        continuation.finish()
+    }
+
+    var received: [EventSourceMessage] = []
+    for try await msg in EventSourceParserStream.makeStream(from: input) {
+        received.append(msg)
+    }
+
+    #expect(received.count == 1)
+    #expect(received.first?.data == "Hello World")
+}
+
+@Test func eventSourceParserStream_splitMultibyteChunkLosesEvents() async throws {
+    // Simulates what makeDataStream() does: yields Data chunks at arbitrary
+    // byte boundaries. When the boundary falls inside a multi-byte UTF-8
+    // character, the parser must carry over the incomplete bytes.
+    let event1 = "data: {\"type\":\"content_block_delta\",\"index\":0}\n\n"
+    let event2 = "data: {\"thinking\":\"The café serves résumés\"}\n\n"
+    let event3 = "data: {\"type\":\"content_block_stop\"}\n\n"
+
+    var allBytes = Data()
+    allBytes.append(Data(event1.utf8))
+    allBytes.append(Data(event2.utf8))
+    allBytes.append(Data(event3.utf8))
+
+    // "é" in "café" is C3 A9. Split between C3 and A9.
+    let eAcuteUTF8 = Data([0xC3, 0xA9])
+    guard let accentRange = allBytes.firstRange(of: eAcuteUTF8) else {
+        Issue.record("Could not find accented character bytes")
+        return
+    }
+    let splitPoint = accentRange.lowerBound + 1
+
+    let chunk1 = Data(allBytes.prefix(splitPoint))
+    let chunk2 = Data(allBytes.suffix(from: splitPoint))
+
+    let input = AsyncThrowingStream<Data, Error> { continuation in
+        continuation.yield(chunk1)
+        continuation.yield(chunk2)
+        continuation.finish()
+    }
+
+    var received: [EventSourceMessage] = []
+    for try await msg in EventSourceParserStream.makeStream(from: input) {
+        received.append(msg)
+    }
+
+    #expect(received.count == 3, "All three events should be received despite multi-byte split")
+    #expect(received[0].data == "{\"type\":\"content_block_delta\",\"index\":0}")
+    #expect(received[1].data == "{\"thinking\":\"The café serves résumés\"}")
+    #expect(received[2].data == "{\"type\":\"content_block_stop\"}")
+}
+
+@Test func eventSourceParserStream_microChunksWithMultibyte() async throws {
+    // Feed the entire payload 3 bytes at a time -- guarantees many
+    // multi-byte characters will be split across chunk boundaries
+    var fixture = ""
+    for i in 0..<3 {
+        fixture += "data: msg\(i) 中文😀\n\n"
+    }
+    let bytes = Data(fixture.utf8)
+
+    let chunkSize = 3
+    let input = AsyncThrowingStream<Data, Error> { continuation in
+        var offset = 0
+        while offset < bytes.count {
+            let end = min(offset + chunkSize, bytes.count)
+            continuation.yield(Data(bytes[offset..<end]))
+            offset = end
+        }
+        continuation.finish()
+    }
+
+    var received: [EventSourceMessage] = []
+    for try await msg in EventSourceParserStream.makeStream(from: input) {
+        received.append(msg)
+    }
+
+    #expect(received.count == 3)
+    for i in 0..<3 {
+        #expect(received[i].data == "msg\(i) 中文😀")
+    }
+}


### PR DESCRIPTION
## Description

I was seeing JSON parsing issues and missing text in tool calls which turns out were caused by the following issue:

`EventSourceParser.feed(_ chunkData: Data)` silently drops entire `Data` chunks when they contain incomplete multi-byte UTF-8 sequences at their boundaries.

The root cause is in `FetchFunction.swift`'s `makeDataStream()`, which buffers raw bytes from `URLSession.AsyncBytes` and yields `Data` chunks at arbitrary 16KB boundaries. When a multi-byte UTF-8 character (accented letter, emoji, CJK, etc.) straddles that boundary:

1. `String(data: chunk, encoding: .utf8)` returns `nil` because the chunk ends with an incomplete UTF-8 sequence
2. The `guard let s = ... else { return }` silently discards the **entire** chunk
3. The next chunk starts with orphaned continuation bytes, which is also invalid UTF-8, so it gets dropped too
4. Up to 32KB of stream data vanishes, causing garbled SSE events and incomplete tool call inputs

The fix adds a `pendingBytes` buffer to `EventSourceParser` that carries incomplete trailing bytes forward to the next `feed()` call. A `utf8SafeSplitIndex` helper finds the last valid UTF-8 character boundary by scanning backwards from the end of the buffer (at most 3 bytes back). The valid prefix is decoded and fed through normally, while the trailing incomplete bytes are held until the next chunk completes them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

N/A — This bug is specific to the Swift port since the typescript code uses built-in byte stream parsing that handles this issue cor

## Testing

- [x] All tests pass (`swift test`) — 3702 tests across 414 suites
- [x] Added tests for new functionality — 13 new tests (10 parser-level, 3 stream-level)
- [ ] Verified upstream parity (if applicable)

### New test coverage

**Parser-level (`ParserTests.swift`):**
- `parser_feedData_asciiOnlyChunks` — ASCII split at every possible byte position
- `parser_feedData_emptyChunks` — empty Data chunks before, between, and after events
- `parser_feedData_split2ByteChar` — 2-byte char (é = C3 A9) split at internal boundary
- `parser_feedData_split3ByteChar` — 3-byte char (中 = E4 B8 AD) split at both internal boundaries
- `parser_feedData_split4ByteChar` — 4-byte char (😀 = F0 9F 98 80) split at all 3 internal boundaries
- `parser_feedData_4ByteCharFedByteByByte` — 4-byte emoji fed as 4 individual 1-byte chunks
- `parser_feedData_consecutiveMultibyteChars` — adjacent emojis with split inside the first
- `parser_feedData_splitMultibyteCorruptsAdjacentEvents` — production scenario reproducing garbled JSON
- `parser_feedData_resetClearsPendingBytes` — reset discards leftover bytes
- `parser_feedData_multipleEventsSpanningManySplits` — 5 events with mixed 2/3/4-byte chars in 3-byte micro-chunks

**Stream-level (`StreamTests.swift`):**
- `eventSourceParserStream_asciiSplitChunks` — ASCII fed byte-by-byte through full pipeline
- `eventSourceParserStream_splitMultibyteChunkLosesEvents` — production scenario end-to-end
- `eventSourceParserStream_microChunksWithMultibyte` — 3 events with CJK + emoji in 3-byte micro-chunks

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [ ] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)