### PR TITLE
Use sorted keys for JSON encoding to enable OpenAI prefix caching

### DIFF
--- a/Sources/AISDKProviderUtils/PostToAPI.swift
+++ b/Sources/AISDKProviderUtils/PostToAPI.swift
@@ -36,7 +36,11 @@ public func postJsonToAPI<T>(
     isAborted: (@Sendable () -> Bool)? = nil,
     fetch: FetchFunction? = nil
 ) async throws -> ResponseHandlerResult<T> {
-    let jsonData = try JSONEncoder().encode(body)
+    // Sorted keys ensure deterministic JSON byte output so providers
+    // that use prefix-based caching (e.g. OpenAI) can match request prefixes.
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let jsonData = try encoder.encode(body)
 
     var mergedHeaders = headers ?? [:]
     mergedHeaders["Content-Type"] = "application/json"


### PR DESCRIPTION
## Description

I was seeing really poor cache rates against the OpenAI API and tracked it down to the fact that their caching mechanism relies on deterministic object serialization:

https://github.com/openai/openai-java/issues/316#issuecomment-2741209762
https://ankitbko.github.io/blog/2025/08/prompt-engineering-kv-cache/#rule-2-master-the-art-of-deterministic-serialization

So basically the serialized JSON string is used in the prefix match routing behavior.

Swift's `JSONEncoder` with default settings produces non-deterministic key ordering for `Dictionary` types. This means consecutive API requests with identical logical content serialize to different byte sequences across calls. OpenAI's [automatic prefix caching](https://platform.openai.com/docs/guides/prompt-caching) requires byte-level prefix matching, so the non-deterministic ordering prevents any cache hits — even when the conversation prefix is identical.

The fix adds `.sortedKeys` to the `JSONEncoder` in `postJsonToAPI`, which is the single serialization chokepoint for all provider HTTP requests. This ensures deterministic alphabetical key ordering at every nesting level (`.sortedKeys` sorts recursively), enabling prefix caching for OpenAI and potentially benefiting any other provider that uses prefix-based caching.

```diff
 ) async throws -> ResponseHandlerResult<T> {
-    let jsonData = try JSONEncoder().encode(body)
+    // Sorted keys ensure deterministic JSON byte output so providers
+    // that use prefix-based caching (e.g. OpenAI) can match request prefixes.
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let jsonData = try encoder.encode(body)
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

Not an upstream port — the Vercel AI SDK (TypeScript) uses `JSON.stringify` which produces deterministic key ordering from object literals. This is a Swift-specific issue because `Dictionary` iteration order is non-deterministic, unlike JavaScript object property enumeration which follows insertion order.

- Upstream file(s): `@ai-sdk/provider-utils/src/post-to-api.ts`
- Upstream commit: N/A

## Testing

- [x] All tests pass (`swift test`)
- [ ] Added tests for new functionality
- [ ] Verified upstream parity (if applicable)

No new tests needed — this is a serialization format change that doesn't affect behavior. JSON key ordering is insignificant per RFC 8259, and all existing tests pass because every compliant parser accepts keys in any order. The observable effect (prefix caching) is only measurable against the live OpenAI API.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [ ] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)

## Additional Notes

- `BlackForestLabsProvider` and `ByteDanceProvider` already use `.sortedKeys` in their own local encoders, so this is consistent with existing practice in the codebase.
