### PR TITLE
Fix streamText step loop not continuing after invalid tool calls

### DIFF
--- a/Sources/SwiftAISDK/GenerateText/StepResult.swift
+++ b/Sources/SwiftAISDK/GenerateText/StepResult.swift
@@ -49,6 +49,9 @@ public protocol StepResult: Sendable {
     /// The results of the tool calls.
     var toolResults: [TypedToolResult] { get }
 
+    /// The errors from invalid or failed tool calls.
+    var toolErrors: [TypedToolError] { get }
+
     /// The static tool results that were made in the last step.
     var staticToolResults: [StaticToolResult] { get }
 
@@ -262,6 +265,15 @@ public final class DefaultStepResult: StepResult {
         content.compactMap { part in
             if case .toolResult(let result, _) = part {
                 return result
+            }
+            return nil
+        }
+    }
+
+    public var toolErrors: [TypedToolError] {
+        content.compactMap { part in
+            if case .toolError(let error, _) = part {
+                return error
             }
             return nil
         }

--- a/Sources/SwiftAISDK/GenerateText/StreamTextActor.swift
+++ b/Sources/SwiftAISDK/GenerateText/StreamTextActor.swift
@@ -211,8 +211,8 @@ actor StreamTextActor {
         guard let lastStep = recordedSteps.last else { return false }
         guard lastStep.finishReason == .toolCalls else { return false }
         let clientToolCalls = clientToolCalls(in: lastStep)
-        let clientToolOutputs = clientToolOutputs(in: lastStep)
-        let clientToolCallsComplete = !clientToolCalls.isEmpty && clientToolOutputs.count == clientToolCalls.count
+        let clientToolOutputCount = clientToolOutputCount(in: lastStep)
+        let clientToolCallsComplete = !clientToolCalls.isEmpty && clientToolOutputCount == clientToolCalls.count
         let stopMet = await isStopConditionMet(stopConditions: stopConditions, steps: recordedSteps)
         return (clientToolCallsComplete || !pendingDeferredToolCalls.isEmpty) && !stopMet
     }
@@ -1379,6 +1379,16 @@ case let .toolInputStart(id, toolName, providerMetadata, providerExecuted, dynam
 
     private func clientToolOutputs(in step: StepResult) -> [TypedToolResult] {
         step.toolResults.filter { $0.providerExecuted != true }
+    }
+
+    /// Counts both successful tool results and tool errors as completed
+    /// outputs. This matches the generateText path's behavior where
+    /// collectInvalidToolOutputs includes errors in the count, ensuring
+    /// the step loop continues when tools fail validation.
+    private func clientToolOutputCount(in step: StepResult) -> Int {
+        let resultCount = step.toolResults.filter { $0.providerExecuted != true }.count
+        let errorCount = step.toolErrors.filter { $0.providerExecuted != true }.count
+        return resultCount + errorCount
     }
 
     private func finalizePendingContent() {

--- a/Tests/SwiftAISDKTests/GenerateText/StreamTextTests.swift
+++ b/Tests/SwiftAISDKTests/GenerateText/StreamTextTests.swift
@@ -2086,3 +2086,161 @@ struct StreamTextBasicTests {
     }
 
 }
+
+// MARK: - Invalid tool call step loop continuation
+
+@Suite("StreamText – invalid tool calls and step loop")
+struct StreamTextInvalidToolCallStepLoopTests {
+    private let defaultUsage = LanguageModelV3Usage(inputTokens: .init(total: 1), outputTokens: .init(total: 1))
+
+    private func toolInputSchema(requiredKey: String = "value") -> FlexibleSchema<JSONValue> {
+        FlexibleSchema(jsonSchema(JSONValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                requiredKey: .object(["type": .string("string")])
+            ]),
+            "required": .array([.string(requiredKey)]),
+            "additionalProperties": .bool(false),
+        ])))
+    }
+
+    @Test("invalid tool call triggers step loop continuation so model can retry")
+    func invalidToolCallContinuesStepLoop() async throws {
+        // Step 1: model sends a tool call with a missing required field.
+        // The SDK validates the input, finds the required key absent,
+        // and emits .toolError. The step finishes with .toolCalls.
+        // The step loop should continue to step 2 where the model
+        // receives the error and responds with text.
+        let stepOneParts: [LanguageModelV3StreamPart] = [
+            .streamStart(warnings: []),
+            .responseMetadata(id: "step-1", modelId: "mock", timestamp: Date(timeIntervalSince1970: 0)),
+            .toolCall(LanguageModelV3ToolCall(
+                toolCallId: "call-1",
+                toolName: "myTool",
+                input: #"{"wrong_key": "value"}"#,
+                providerExecuted: false,
+                providerMetadata: nil
+            )),
+            .finish(finishReason: LanguageModelV3FinishReason(unified: .toolCalls), usage: defaultUsage, providerMetadata: nil),
+        ]
+
+        // Step 2: model sees the error and produces a text response
+        let stepTwoParts: [LanguageModelV3StreamPart] = [
+            .streamStart(warnings: []),
+            .responseMetadata(id: "step-2", modelId: "mock", timestamp: Date(timeIntervalSince1970: 1)),
+            .textStart(id: "t-1", providerMetadata: nil),
+            .textDelta(id: "t-1", delta: "I see the error", providerMetadata: nil),
+            .textEnd(id: "t-1", providerMetadata: nil),
+            .finish(finishReason: LanguageModelV3FinishReason(unified: .stop), usage: defaultUsage, providerMetadata: nil),
+        ]
+
+        let stream1 = AsyncThrowingStream<LanguageModelV3StreamPart, Error> { c in
+            for p in stepOneParts { c.yield(p) }
+            c.finish()
+        }
+        let stream2 = AsyncThrowingStream<LanguageModelV3StreamPart, Error> { c in
+            for p in stepTwoParts { c.yield(p) }
+            c.finish()
+        }
+
+        let model = MockLanguageModelV3(
+            doStream: .array([
+                LanguageModelV3StreamResult(stream: stream1),
+                LanguageModelV3StreamResult(stream: stream2),
+            ])
+        )
+
+        let tools: ToolSet = [
+            "myTool": tool(
+                inputSchema: toolInputSchema(requiredKey: "value"),
+                execute: { _, _ in .value(.string("should not be called")) }
+            ),
+        ]
+
+        let result: DefaultStreamTextResult<JSONValue, JSONValue> = try streamText(
+            model: .v3(model),
+            prompt: "hello",
+            tools: tools,
+            stopWhen: [stepCountIs(3)]
+        )
+
+        let text = try await result.readAllText()
+        #expect(text == "I see the error")
+
+        let steps = try await result.steps
+        #expect(steps.count == 2, "Step loop should continue after invalid tool call so the model can see the error and retry")
+        #expect(steps.first?.finishReason == .toolCalls)
+        #expect(steps.last?.finishReason == .stop)
+
+        // The model should have been called twice (once for each step)
+        #expect(model.doStreamCalls.count == 2)
+    }
+
+    @Test("invalid tool call error appears in response messages for next step")
+    func invalidToolCallErrorInResponseMessages() async throws {
+        // Even with a single step, the error should be recorded in the
+        // response messages so it would be available for continuation
+        let parts: [LanguageModelV3StreamPart] = [
+            .streamStart(warnings: []),
+            .responseMetadata(id: "step-1", modelId: "mock", timestamp: Date(timeIntervalSince1970: 0)),
+            .toolCall(LanguageModelV3ToolCall(
+                toolCallId: "call-1",
+                toolName: "myTool",
+                input: #"{"wrong_key": "value"}"#,
+                providerExecuted: false,
+                providerMetadata: nil
+            )),
+            .finish(finishReason: LanguageModelV3FinishReason(unified: .toolCalls), usage: defaultUsage, providerMetadata: nil),
+        ]
+
+        let stream = AsyncThrowingStream<LanguageModelV3StreamPart, Error> { c in
+            for p in parts { c.yield(p) }
+            c.finish()
+        }
+
+        let model = MockLanguageModelV3(
+            doStream: .singleValue(LanguageModelV3StreamResult(stream: stream))
+        )
+
+        let tools: ToolSet = [
+            "myTool": tool(
+                inputSchema: toolInputSchema(requiredKey: "value"),
+                execute: { _, _ in .value(.string("should not be called")) }
+            ),
+        ]
+
+        let result: DefaultStreamTextResult<JSONValue, JSONValue> = try streamText(
+            model: .v3(model),
+            prompt: "hello",
+            tools: tools
+        )
+
+        _ = try await result.readAllText()
+        let steps = try await result.steps
+        let step = try #require(steps.first)
+
+        // The step should contain a tool error in its content
+        let hasToolError = step.content.contains { part in
+            if case .toolError = part { return true }
+            return false
+        }
+        #expect(hasToolError, "Step content should include the tool error")
+
+        // The response messages should convert the error into a tool
+        // result message so the model can see what went wrong
+        let messages = try await result.response.messages
+        let toolMessage = messages.first { msg in
+            if case .tool = msg { return true }
+            return false
+        }
+        #expect(toolMessage != nil, "Response messages should include a tool message with the error")
+
+        if case .tool(let toolMsg) = toolMessage {
+            let errorPart = toolMsg.content.first { part in
+                if case .toolResult(let r) = part, case .errorText = r.output { return true }
+                return false
+            }
+            #expect(errorPart != nil, "Tool message should contain an errorText result")
+        }
+    }
+}

--- a/Tests/SwiftAISDKTests/GenerateText/StreamTextToolErrorProviderMetadataTests.swift
+++ b/Tests/SwiftAISDKTests/GenerateText/StreamTextToolErrorProviderMetadataTests.swift
@@ -96,14 +96,17 @@ struct StreamTextToolErrorProviderMetadataTests {
             Issue.record("Expected fullStream to contain a tool-error part.")
         }
 
-        let content = try await result.content
-        if let part = content.first(where: { if case .toolError = $0 { return true } else { return false } }) {
+        // The tool error is in step 1's content (step 2 is the retry
+        // with a text response now that the step loop continues)
+        let steps = try await result.steps
+        let step1 = try #require(steps.first)
+        if let part = step1.content.first(where: { if case .toolError = $0 { return true } else { return false } }) {
             if case .toolError(let error, let providerMetadata) = part {
                 #expect(error.providerMetadata == meta)
                 #expect(providerMetadata == meta)
             }
         } else {
-            Issue.record("Expected content to contain a tool-error part.")
+            Issue.record("Expected step 1 content to contain a tool-error part.")
         }
     }
 }


### PR DESCRIPTION
## Description

I was seeing the agent loop die in the middle of concurrent tool calls without any real explanation why. I tracked it down to a logic error in the AI SDK. This patch fixes the bug, moving the Swift port more in line with the TypeScript code.

The streaming path's `shouldStartAnotherStep()` only counted `.toolResult` items when checking whether all tool calls in a step were complete. Tool errors from invalid input (e.g. missing required fields that fail schema validation) were excluded from the count. When **all** tools in a step failed validation, `clientToolOutputs.count` was 0 while `clientToolCalls.count` was > 0, so the equality check failed and the step loop terminated — silently dropping the errors instead of sending them back to the model for retry.

The non-streaming `generateText` path already handled this correctly: its `clientToolOutputs` array (of type `ToolOutput`, a union of `TypedToolResult | TypedToolError`) is populated from both `tool-result` and `tool-error` events. The streaming path was using `step.toolResults` (results only) instead of counting both.

### Changes

- **`StepResult.swift`** — Added `toolErrors` computed property that extracts `TypedToolError` items from step content, mirroring the existing `toolResults` property.
- **`StreamTextActor.swift`** — Replaced the `clientToolOutputs(in:)` call in `shouldStartAnotherStep()` with a new `clientToolOutputCount(in:)` helper that sums both `toolResults` and `toolErrors` (filtered by `providerExecuted != true`), matching the upstream `clientToolOutputs.length === clientToolCalls.length` check.
- **`StreamTextTests.swift`** — Added two tests: one verifying the step loop continues after invalid tool calls so the model can retry, and one verifying the error appears in response messages.
- **`StreamTextToolErrorProviderMetadataTests.swift`** — Updated existing test to account for the step loop now continuing (tool error is in step 1's content, not the final step).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

The upstream TypeScript tracks tool outputs in a single `stepToolOutputs` array of type `Array<ToolOutput<TOOLS>>`, where `ToolOutput = TypedToolResult | TypedToolError`. Both `tool-result` and `tool-error` stream events push into this array, so the loop condition `clientToolOutputs.length === clientToolCalls.length` naturally counts errors as completed outputs.

- Upstream file(s): `packages/ai/src/generate-text/stream-text.ts` (flush handler in `streamStep`, around the `clientToolOutputs.length === clientToolCalls.length` check)
- Upstream commit: N/A — the upstream never had this bug because `ToolOutput` is a union type and `stepToolOutputs.push(chunk)` appears in both the `tool-result` and `tool-error` switch cases.

## Testing

- [x] All tests pass (`swift test`)
- [x] Added tests for new functionality
- [x] Verified upstream parity (if applicable)

### New tests

- **`invalidToolCallContinuesStepLoop`** — Two-step scenario: step 1 sends a tool call with a missing required field, the SDK emits a tool error, and the step loop should continue to step 2 where the model responds with text. Asserts `steps.count == 2` and that the model was called twice.
- **`invalidToolCallErrorInResponseMessages`** — Single-step scenario verifying that the tool error appears in step content and response messages (as an `errorText` tool result) so it would be available to the model in a continuation.

### Updated tests

- **`StreamTextToolErrorProviderMetadataTests`** — The existing provider metadata test now accounts for the step loop continuing: the tool error is in step 1's content rather than the final step's content.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [ ] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)

## Additional Notes

The Swift SDK models `StepResult.toolResults` and the new `StepResult.toolErrors` as separate computed properties (rather than a single `toolOutputs` property) because the Swift type system uses separate concrete types (`TypedToolResult` and `TypedToolError`) rather than a discriminated union. The `clientToolOutputCount` helper bridges this by summing both counts, achieving the same semantics as the upstream's single-array approach.
