### PR TITLE
Use sorted keys for inner JSON encoders on prompt serialization paths

### DIFF
--- a/Sources/AnthropicProvider/ConvertToAnthropicMessagesPrompt.swift
+++ b/Sources/AnthropicProvider/ConvertToAnthropicMessagesPrompt.swift
@@ -957,7 +957,9 @@ private func appendAssistantToolResult(
 }
 
 private func jsonString(from value: JSONValue) throws -> String {
-    let data = try JSONEncoder().encode(value)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(value)
     guard let string = String(data: data, encoding: .utf8) else {
         throw UnsupportedFunctionalityError(functionality: "JSON serialization")
     }

--- a/Sources/OpenAIProvider/Chat/OpenAIChatPrompt.swift
+++ b/Sources/OpenAIProvider/Chat/OpenAIChatPrompt.swift
@@ -223,7 +223,7 @@ struct OpenAIChatMessagesConverter {
 
     private static func encodeJSONValue(_ value: JSONValue) throws -> String {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.withoutEscapingSlashes]
+        encoder.outputFormatting = [.withoutEscapingSlashes, .sortedKeys]
         let data = try encoder.encode(value)
         guard let string = String(data: data, encoding: .utf8) else {
             throw UnsupportedFunctionalityError(functionality: "Unable to encode JSON value")
@@ -233,6 +233,7 @@ struct OpenAIChatMessagesConverter {
 
     private static func encodeEncodable<T: Encodable>(_ value: T) throws -> String {
         let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(value)
         guard let string = String(data: data, encoding: .utf8) else {
             throw UnsupportedFunctionalityError(functionality: "Unable to encode JSON value")

--- a/Sources/OpenAIProvider/OpenAIResponsesInput.swift
+++ b/Sources/OpenAIProvider/OpenAIResponsesInput.swift
@@ -847,7 +847,9 @@ struct OpenAIResponsesInputBuilder {
     }
 
     private static func encodeJSONStringifiedValue(_ value: JSONValue) throws -> String {
-        let data = try JSONEncoder().encode(value)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
         guard let string = String(data: data, encoding: .utf8) else {
             throw UnsupportedFunctionalityError(functionality: "Unable to encode JSON value")
         }

--- a/Tests/AnthropicProviderTests/ConvertToAnthropicMessagesPromptTests.swift
+++ b/Tests/AnthropicProviderTests/ConvertToAnthropicMessagesPromptTests.swift
@@ -358,6 +358,82 @@ struct ConvertToAnthropicMessagesPromptToolTests {
 
 // MARK: - Assistant Messages
 
+// MARK: - JSON Key Ordering Stability
+
+@Suite("convertToAnthropicMessagesPrompt JSON key ordering")
+struct ConvertToAnthropicMessagesPromptKeyOrderingTests {
+    @Test("tool result with json output uses sorted keys")
+    func toolResultJSONUsesSortedKeys() async throws {
+        // An object with keys that sort differently than hash order.
+        // Without .sortedKeys, Swift dictionaries iterate in non-deterministic
+        // hash order, producing different JSON strings across process launches.
+        let toolPart = LanguageModelV3ToolResultPart(
+            toolCallId: "call-1",
+            toolName: "mcp_tool",
+            output: .json(value: .object([
+                "zebra": .string("last"),
+                "alpha": .string("first"),
+                "middle": .number(42),
+            ]))
+        )
+        let prompt: LanguageModelV3Prompt = [
+            .tool(content: [.toolResult(toolPart)], providerOptions: nil)
+        ]
+
+        let (result, _) = try await convert(prompt)
+        let msg = try #require(result.prompt.messages.first)
+        let block = try #require(msg.content.first)
+
+        // Extract the stringified content field
+        guard case .object(let obj) = block,
+              case .string(let contentString) = obj["content"] else {
+            Issue.record("Expected tool_result with string content")
+            return
+        }
+
+        // Keys must appear in sorted order: alpha, middle, zebra
+        let alphaIdx = try #require(contentString.range(of: "\"alpha\""))
+        let middleIdx = try #require(contentString.range(of: "\"middle\""))
+        let zebraIdx = try #require(contentString.range(of: "\"zebra\""))
+        #expect(alphaIdx.lowerBound < middleIdx.lowerBound, "alpha should come before middle")
+        #expect(middleIdx.lowerBound < zebraIdx.lowerBound, "middle should come before zebra")
+    }
+
+    @Test("tool result json output is byte-stable across repeated conversions")
+    func toolResultJSONByteStable() async throws {
+        let toolPart = LanguageModelV3ToolResultPart(
+            toolCallId: "call-1",
+            toolName: "mcp_tool",
+            output: .json(value: .object([
+                "zebra": .string("z"),
+                "alpha": .string("a"),
+                "nested": .object(["beta": .number(1), "alpha": .number(2)]),
+            ]))
+        )
+        let prompt: LanguageModelV3Prompt = [
+            .tool(content: [.toolResult(toolPart)], providerOptions: nil)
+        ]
+
+        // Convert multiple times — results must be byte-identical
+        // Use .sortedKeys to match the production postJsonToAPI encoder
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var results: [String] = []
+        for _ in 0..<10 {
+            let (result, _) = try await convert(prompt)
+            let data = try encoder.encode(result.prompt.messages)
+            results.append(String(data: data, encoding: .utf8)!)
+        }
+
+        let first = results[0]
+        for (i, r) in results.enumerated().dropFirst() {
+            #expect(r == first, "Conversion \(i) differs from first — key ordering is non-deterministic")
+        }
+    }
+}
+
+// MARK: - Assistant Messages
+
 @Suite("convertToAnthropicMessagesPrompt assistant messages")
 struct ConvertToAnthropicMessagesPromptAssistantTests {
     @Test("assistant text trims final whitespace")


### PR DESCRIPTION
## Description

This is a follow-on from my previous patch:
https://github.com/teunlao/swift-ai-sdk/pull/16

That patch used `.sortedKeys` to ensure that request serialization resulted in a deterministic key ordering which helped to increase cache hits.

As it turns out, there are several more places where we use `JSONEncoder()` that need this fix in order to maintain high cache rates for tool use.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

N/A — This is a Swift-specific issue. The TypeScript SDK uses `JSON.stringify()` which produces deterministic key ordering (insertion order per ES2015 spec), so this problem doesn't exist upstream.

## Testing

- [x] All tests pass (`swift test`)
- [x] Added tests for new functionality
- [ ] Verified upstream parity (if applicable)

### New tests

Added `ConvertToAnthropicMessagesPromptKeyOrderingTests` suite with 2 tests:

- **`toolResultJSONUsesSortedKeys`** — Converts a tool result with keys `zebra`, `alpha`, `middle` and verifies they appear in alphabetical order in the serialized content string
- **`toolResultJSONByteStable`** — Converts the same prompt with nested objects 10 times and asserts all results are byte-identical

Both tests were verified to fail without the fix and pass with it.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [x] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)

## Additional Notes

The fix is minimal and surgical — each inner encoder just needs `.sortedKeys` added to its `outputFormatting`. The `encodeJSONValue` in `OpenAIChatPrompt.swift` already had `.withoutEscapingSlashes`; `.sortedKeys` was added alongside it. The other functions had bare `JSONEncoder()` instances.

There are many more `JSONEncoder()` calls throughout the SDK (in other providers, telemetry, MCP protocol, etc.) but they are not on the prompt serialization path — they either handle response parsing, telemetry attributes, or protocol wire formats that don't affect prompt caching. Only the 4 functions above produce strings that end up embedded in the AI provider request body.
