### PR TITLE
Release v0.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.17.6] - 2026-03-30
+
+### Fixed
+- Tests/CI: vendor tracked fixtures into the repository for release/CI stability instead of relying on transient local state.
+- OpenAI Responses: refresh capability gates and model-id allowlists to the latest upstream surface, including `gpt-5.3-chat-latest`, `gpt-5.4-mini*`, and `gpt-5.4-nano*`, while removing stale legacy IDs and aligning `gpt-5.4-nano` priority-processing behavior.
+
 ## [0.17.5] - 2026-03-22
 
 Upstream parity refresh against Vercel AI SDK commit `a921fbb381cf2d19ef75ae27906f8d1cb0b8325b`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [0.17.6] - 2026-03-30
 
 ### Fixed
-- Tests/CI: vendor tracked fixtures into the repository for release/CI stability instead of relying on transient local state.
-- OpenAI Responses: refresh capability gates and model-id allowlists to the latest upstream surface, including `gpt-5.3-chat-latest`, `gpt-5.4-mini*`, and `gpt-5.4-nano*`, while removing stale legacy IDs and aligning `gpt-5.4-nano` priority-processing behavior.
+- Tests/CI: vendor tracked fixtures into the repository for stable release and CI checkouts instead of relying on transient local state.
+- EventSourceParser: preserve `Data` chunks when multibyte UTF-8 characters are split across parser boundaries.
+- StreamText: keep the step loop advancing after invalid tool calls instead of stalling.
+- OpenAI: sort JSON keys in request encoding so prefix caching stays stable.
+- Anthropic: serialize top-level `cache_control` for automatic caching requests.
+- OpenAI Responses: refresh capability gates and model-id allowlists to the latest model surface, including `gpt-5.3-chat-latest`, `gpt-5.4-mini*`, and `gpt-5.4-nano*`, while removing stale legacy IDs and aligning `gpt-5.4-nano` priority-processing behavior.
 
 ## [0.17.5] - 2026-03-22
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Add the package to your `Package.swift`:
 ```swift
 // Package.swift
 dependencies: [
-  // Use the latest release tag (e.g. "0.17.5").
-  .package(url: "https://github.com/teunlao/swift-ai-sdk.git", from: "0.17.5")
+  // Use the latest release tag (e.g. "0.17.6").
+  .package(url: "https://github.com/teunlao/swift-ai-sdk.git", from: "0.17.6")
 ],
 targets: [
   .target(
@@ -122,7 +122,7 @@ let summary = try await generateObject(
   model: openai("gpt-5"),
   schema: Release.self,
   schemaName: "release_summary",
-  prompt: "Summarize Swift AI SDK 0.17.5: streaming + tools."
+  prompt: "Summarize Swift AI SDK 0.17.6: streaming + tools."
 ).object
 
 print("Release: \\(summary.name) (\\(summary.version))")

--- a/Sources/AISDKProviderUtils/Versioning/SDKReleaseVersion.swift
+++ b/Sources/AISDKProviderUtils/Versioning/SDKReleaseVersion.swift
@@ -3,5 +3,5 @@ import Foundation
 /// Shared release version used across all providers.
 public enum SDKReleaseVersion {
     /// Returns the release version string.
-    public static let value: String = "0.17.5"
+    public static let value: String = "0.17.6"
 }

--- a/Sources/OpenAIProvider/OpenAILanguageModelCapabilities.swift
+++ b/Sources/OpenAIProvider/OpenAILanguageModelCapabilities.swift
@@ -17,8 +17,10 @@ func getOpenAILanguageModelCapabilities(for modelId: String) -> OpenAILanguageMo
 
     let supportsPriorityProcessing =
         modelId.hasPrefix("gpt-4")
-        || modelId.hasPrefix("gpt-5-mini")
-        || (modelId.hasPrefix("gpt-5") && !modelId.hasPrefix("gpt-5-nano") && !modelId.hasPrefix("gpt-5-chat"))
+        || (modelId.hasPrefix("gpt-5")
+            && !modelId.hasPrefix("gpt-5-nano")
+            && !modelId.hasPrefix("gpt-5-chat")
+            && !modelId.hasPrefix("gpt-5.4-nano"))
         || modelId.hasPrefix("o3")
         || modelId.hasPrefix("o4-mini")
 
@@ -28,15 +30,14 @@ func getOpenAILanguageModelCapabilities(for modelId: String) -> OpenAILanguageMo
         modelId.hasPrefix("o1")
         || modelId.hasPrefix("o3")
         || modelId.hasPrefix("o4-mini")
-        || modelId.hasPrefix("codex-mini")
-        || modelId.hasPrefix("computer-use-preview")
         || (modelId.hasPrefix("gpt-5") && !modelId.hasPrefix("gpt-5-chat"))
 
     // https://platform.openai.com/docs/guides/latest-model#gpt-5-1-parameter-compatibility
-    // GPT-5.1, GPT-5.2, and GPT-5.4 support temperature/topP/logprobs when reasoningEffort is none.
+    // GPT-5.1, GPT-5.2, GPT-5.3, and GPT-5.4 support temperature/topP/logprobs when reasoningEffort is none.
     let supportsNonReasoningParameters =
         modelId.hasPrefix("gpt-5.1")
         || modelId.hasPrefix("gpt-5.2")
+        || modelId.hasPrefix("gpt-5.3")
         || modelId.hasPrefix("gpt-5.4")
 
     let systemMessageMode: OpenAIResponsesSystemMessageMode = isReasoningModel ? .developer : .system

--- a/Sources/OpenAIProvider/OpenAIResponsesOptions.swift
+++ b/Sources/OpenAIProvider/OpenAIResponsesOptions.swift
@@ -9,16 +9,10 @@ public let openAIResponsesReasoningModelIds: [OpenAIResponsesModelId] = [
     "o1-2024-12-17",
     "o3",
     "o3-2025-04-16",
-    "o3-deep-research",
-    "o3-deep-research-2025-06-26",
     "o3-mini",
     "o3-mini-2025-01-31",
     "o4-mini",
     "o4-mini-2025-04-16",
-    "o4-mini-deep-research",
-    "o4-mini-deep-research-2025-06-26",
-    "codex-mini-latest",
-    "computer-use-preview",
     "gpt-5",
     "gpt-5-2025-08-07",
     "gpt-5-codex",
@@ -37,11 +31,16 @@ public let openAIResponsesReasoningModelIds: [OpenAIResponsesModelId] = [
     "gpt-5.2-chat-latest",
     "gpt-5.2-pro",
     "gpt-5.2-codex",
+    "gpt-5.3-chat-latest",
+    "gpt-5.3-codex",
     "gpt-5.4",
     "gpt-5.4-2026-03-05",
+    "gpt-5.4-mini",
+    "gpt-5.4-mini-2026-03-17",
+    "gpt-5.4-nano",
+    "gpt-5.4-nano-2026-03-17",
     "gpt-5.4-pro",
-    "gpt-5.4-pro-2026-03-05",
-    "gpt-5.3-codex"
+    "gpt-5.4-pro-2026-03-05"
 ].map(OpenAIResponsesModelId.init(rawValue:))
 
 public let openAIResponsesModelIds: [OpenAIResponsesModelId] = (
@@ -57,7 +56,6 @@ public let openAIResponsesModelIds: [OpenAIResponsesModelId] = (
         "gpt-4o-2024-08-06",
         "gpt-4o-2024-11-20",
         "gpt-4o-audio-preview",
-        "gpt-4o-audio-preview-2024-10-01",
         "gpt-4o-audio-preview-2024-12-17",
         "gpt-4o-search-preview",
         "gpt-4o-search-preview-2025-03-11",
@@ -65,19 +63,9 @@ public let openAIResponsesModelIds: [OpenAIResponsesModelId] = (
         "gpt-4o-mini-search-preview-2025-03-11",
         "gpt-4o-mini",
         "gpt-4o-mini-2024-07-18",
-        "gpt-4-turbo",
-        "gpt-4-turbo-2024-04-09",
-        "gpt-4-turbo-preview",
-        "gpt-4-0125-preview",
-        "gpt-4-1106-preview",
-        "gpt-4",
-        "gpt-4-0613",
-        "gpt-4.5-preview",
-        "gpt-4.5-preview-2025-02-27",
         "gpt-3.5-turbo-0125",
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-1106",
-        "chatgpt-4o-latest",
         "gpt-5-chat-latest"
     ] + openAIResponsesReasoningModelIds.map { $0.rawValue }
 ).map(OpenAIResponsesModelId.init(rawValue:))

--- a/Tests/SwiftAISDKTests/OpenAI/OpenAILanguageModelCapabilitiesTests.swift
+++ b/Tests/SwiftAISDKTests/OpenAI/OpenAILanguageModelCapabilitiesTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Suite("OpenAILanguageModelCapabilities")
 struct OpenAILanguageModelCapabilitiesTests {
-    @Test("isReasoningModel matches upstream allowlist")
+    @Test("isReasoningModel matches refreshed upstream allowlist")
     func isReasoningModel() {
         let cases: [(String, Bool)] = [
             ("gpt-4.1", false),
@@ -17,7 +17,6 @@ struct OpenAILanguageModelCapabilitiesTests {
             ("gpt-4o-2024-08-06", false),
             ("gpt-4o-2024-11-20", false),
             ("gpt-4o-audio-preview", false),
-            ("gpt-4o-audio-preview-2024-10-01", false),
             ("gpt-4o-audio-preview-2024-12-17", false),
             ("gpt-4o-search-preview", false),
             ("gpt-4o-search-preview-2025-03-11", false),
@@ -25,19 +24,9 @@ struct OpenAILanguageModelCapabilitiesTests {
             ("gpt-4o-mini-search-preview-2025-03-11", false),
             ("gpt-4o-mini", false),
             ("gpt-4o-mini-2024-07-18", false),
-            ("gpt-4-turbo", false),
-            ("gpt-4-turbo-2024-04-09", false),
-            ("gpt-4-turbo-preview", false),
-            ("gpt-4-0125-preview", false),
-            ("gpt-4-1106-preview", false),
-            ("gpt-4", false),
-            ("gpt-4-0613", false),
-            ("gpt-4.5-preview", false),
-            ("gpt-4.5-preview-2025-02-27", false),
             ("gpt-3.5-turbo-0125", false),
             ("gpt-3.5-turbo", false),
             ("gpt-3.5-turbo-1106", false),
-            ("chatgpt-4o-latest", false),
             ("gpt-5-chat-latest", false),
             ("o1", true),
             ("o1-2024-12-17", true),
@@ -47,8 +36,8 @@ struct OpenAILanguageModelCapabilitiesTests {
             ("o3-2025-04-16", true),
             ("o4-mini", true),
             ("o4-mini-2025-04-16", true),
-            ("codex-mini-latest", true),
-            ("computer-use-preview", true),
+            ("codex-mini-latest", false),
+            ("computer-use-preview", false),
             ("gpt-5", true),
             ("gpt-5-2025-08-07", true),
             ("gpt-5-codex", true),
@@ -58,6 +47,10 @@ struct OpenAILanguageModelCapabilitiesTests {
             ("gpt-5-nano-2025-08-07", true),
             ("gpt-5-pro", true),
             ("gpt-5-pro-2025-10-06", true),
+            ("gpt-5.4-mini", true),
+            ("gpt-5.4-mini-2026-03-17", true),
+            ("gpt-5.4-nano", true),
+            ("gpt-5.4-nano-2026-03-17", true),
             ("new-unknown-model", false),
             ("ft:gpt-4o-2024-08-06:org:custom:abc123", false),
             ("custom-model", false)
@@ -71,7 +64,32 @@ struct OpenAILanguageModelCapabilitiesTests {
         }
     }
 
-    @Test("supportsNonReasoningParameters matches upstream")
+    @Test("supportsPriorityProcessing matches refreshed upstream exclusions")
+    func supportsPriorityProcessing() {
+        let cases: [(String, Bool)] = [
+            ("gpt-4.1", true),
+            ("gpt-5", true),
+            ("gpt-5-mini", true),
+            ("gpt-5-nano", false),
+            ("gpt-5-chat-latest", false),
+            ("gpt-5.3-chat-latest", true),
+            ("gpt-5.4-mini", true),
+            ("gpt-5.4-nano", false),
+            ("gpt-5.4-nano-2026-03-17", false),
+            ("o3", true),
+            ("o4-mini", true),
+            ("custom-model", false)
+        ]
+
+        for (modelId, expected) in cases {
+            #expect(
+                getOpenAILanguageModelCapabilities(for: modelId).supportsPriorityProcessing == expected,
+                "Model \(modelId) priority processing mismatch"
+            )
+        }
+    }
+
+    @Test("supportsNonReasoningParameters matches refreshed upstream")
     func supportsNonReasoningParameters() {
         let cases: [(String, Bool)] = [
             ("gpt-5.1", true),
@@ -81,9 +99,14 @@ struct OpenAILanguageModelCapabilitiesTests {
             ("gpt-5.2", true),
             ("gpt-5.2-pro", true),
             ("gpt-5.2-chat-latest", true),
+            ("gpt-5.3-chat-latest", true),
             ("gpt-5.4", true),
+            ("gpt-5.4-mini", true),
+            ("gpt-5.4-nano", true),
             ("gpt-5.4-pro", true),
             ("gpt-5.4-2026-03-05", true),
+            ("gpt-5.4-mini-2026-03-17", true),
+            ("gpt-5.4-nano-2026-03-17", true),
             ("gpt-5", false),
             ("gpt-5-mini", false),
             ("gpt-5-nano", false),
@@ -99,15 +122,39 @@ struct OpenAILanguageModelCapabilitiesTests {
         }
     }
 
-    @Test("responses model lists include latest GPT-5.4 and Codex ids")
-    func responsesModelListsIncludeLatestIds() {
+    @Test("responses model lists match refreshed upstream additions and removals")
+    func responsesModelListsMatchRefreshedUpstream() {
         let expectedReasoningIds = [
             "gpt-5.2-codex",
+            "gpt-5.3-chat-latest",
+            "gpt-5.3-codex",
             "gpt-5.4",
             "gpt-5.4-2026-03-05",
+            "gpt-5.4-mini",
+            "gpt-5.4-mini-2026-03-17",
+            "gpt-5.4-nano",
+            "gpt-5.4-nano-2026-03-17",
             "gpt-5.4-pro",
-            "gpt-5.4-pro-2026-03-05",
-            "gpt-5.3-codex"
+            "gpt-5.4-pro-2026-03-05"
+        ]
+
+        let removedReasoningIds = [
+            "codex-mini-latest",
+            "computer-use-preview"
+        ]
+
+        let removedModelIds = [
+            "gpt-4o-audio-preview-2024-10-01",
+            "gpt-4-turbo",
+            "gpt-4-turbo-2024-04-09",
+            "gpt-4-turbo-preview",
+            "gpt-4-0125-preview",
+            "gpt-4-1106-preview",
+            "gpt-4",
+            "gpt-4-0613",
+            "gpt-4.5-preview",
+            "gpt-4.5-preview-2025-02-27",
+            "chatgpt-4o-latest"
         ]
 
         let reasoningIds = Set(openAIResponsesReasoningModelIds.map(\.rawValue))
@@ -116,6 +163,15 @@ struct OpenAILanguageModelCapabilitiesTests {
         for modelId in expectedReasoningIds {
             #expect(reasoningIds.contains(modelId), "Missing reasoning model id \(modelId)")
             #expect(modelIds.contains(modelId), "Missing responses model id \(modelId)")
+        }
+
+        for modelId in removedReasoningIds {
+            #expect(!reasoningIds.contains(modelId), "Unexpected legacy reasoning model id \(modelId)")
+            #expect(!modelIds.contains(modelId), "Unexpected legacy responses model id \(modelId)")
+        }
+
+        for modelId in removedModelIds {
+            #expect(!modelIds.contains(modelId), "Unexpected legacy responses model id \(modelId)")
         }
     }
 }

--- a/apps/docs/src/content/docs/providers/alibaba.mdx
+++ b/apps/docs/src/content/docs/providers/alibaba.mdx
@@ -16,7 +16,7 @@ The Alibaba provider is available in the `AlibabaProvider` module. Add it to you
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/anthropic.mdx
+++ b/apps/docs/src/content/docs/providers/anthropic.mdx
@@ -16,7 +16,7 @@ The Anthropic provider is available in the `AnthropicProvider` module. Add it to
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/black-forest-labs.mdx
+++ b/apps/docs/src/content/docs/providers/black-forest-labs.mdx
@@ -14,7 +14,7 @@ The Black Forest Labs provider is available in the `BlackForestLabsProvider` mod
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/bytedance.mdx
+++ b/apps/docs/src/content/docs/providers/bytedance.mdx
@@ -16,7 +16,7 @@ The ByteDance provider is available in the `ByteDanceProvider` module. Add it to
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/cohere.mdx
+++ b/apps/docs/src/content/docs/providers/cohere.mdx
@@ -16,7 +16,7 @@ The Cohere provider is available in the `CohereProvider` module. Add it to your 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/fal.mdx
+++ b/apps/docs/src/content/docs/providers/fal.mdx
@@ -14,7 +14,7 @@ The Fal provider is available in the `FalProvider` module. Add it to your Swift 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/google-generative-ai.mdx
+++ b/apps/docs/src/content/docs/providers/google-generative-ai.mdx
@@ -17,7 +17,7 @@ The Google Generative AI provider is available in the `GoogleProvider` module. A
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/klingai.mdx
+++ b/apps/docs/src/content/docs/providers/klingai.mdx
@@ -16,7 +16,7 @@ The Kling AI provider is available in the `KlingAIProvider` module. Add it to yo
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/lmnt.mdx
+++ b/apps/docs/src/content/docs/providers/lmnt.mdx
@@ -14,7 +14,7 @@ Add the library via Swift Package Manager and include these products:
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/mistral.mdx
+++ b/apps/docs/src/content/docs/providers/mistral.mdx
@@ -16,7 +16,7 @@ The Mistral provider is available in the `MistralProvider` module. Add it to you
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/moonshotai.mdx
+++ b/apps/docs/src/content/docs/providers/moonshotai.mdx
@@ -16,7 +16,7 @@ The Moonshot AI provider is available in the `MoonshotAIProvider` module. Add it
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/open-responses.mdx
+++ b/apps/docs/src/content/docs/providers/open-responses.mdx
@@ -14,7 +14,7 @@ The Open Responses provider is available in the `OpenResponsesProvider` module. 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/openai.mdx
+++ b/apps/docs/src/content/docs/providers/openai.mdx
@@ -16,7 +16,7 @@ The OpenAI provider is available in the `OpenAIProvider` module. Add it to your 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/perplexity.mdx
+++ b/apps/docs/src/content/docs/providers/perplexity.mdx
@@ -18,7 +18,7 @@ The Perplexity provider is available in the `PerplexityProvider` module. Add it 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/prodia.mdx
+++ b/apps/docs/src/content/docs/providers/prodia.mdx
@@ -14,7 +14,7 @@ The Prodia provider is available in the `ProdiaProvider` module. Add it to your 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/replicate.mdx
+++ b/apps/docs/src/content/docs/providers/replicate.mdx
@@ -15,7 +15,7 @@ Add the library via Swift Package Manager and include these products:
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/revai.mdx
+++ b/apps/docs/src/content/docs/providers/revai.mdx
@@ -14,7 +14,7 @@ The Rev.ai provider is available in the `RevAIProvider` module. Add it to your S
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/togetherai.mdx
+++ b/apps/docs/src/content/docs/providers/togetherai.mdx
@@ -14,7 +14,7 @@ The Together.ai provider is available in the `TogetherAIProvider` module. Add it
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/vercel.mdx
+++ b/apps/docs/src/content/docs/providers/vercel.mdx
@@ -27,7 +27,7 @@ The Vercel provider is available in the `VercelProvider` module. Add it to your 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.5")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
 ],
 targets: [
   .target(


### PR DESCRIPTION
## Fixed
- Tests/CI: vendor tracked fixtures into the repository for stable release and CI checkouts instead of relying on transient local state.
- EventSourceParser: preserve `Data` chunks when multibyte UTF-8 characters are split across parser boundaries.
- StreamText: keep the step loop advancing after invalid tool calls instead of stalling.
- OpenAI: sort JSON keys in request encoding so prefix caching stays stable.
- Anthropic: serialize top-level `cache_control` for automatic caching requests.
- OpenAI Responses: refresh capability gates and model-id allowlists to the latest model surface, including `gpt-5.3-chat-latest`, `gpt-5.4-mini*`, and `gpt-5.4-nano*`, while removing stale legacy IDs and aligning `gpt-5.4-nano` priority-processing behavior.
