### PR TITLE
Add Codable conformance to ModelMessage and all part types

### DIFF
--- a/Sources/AISDKProviderUtils/ContentPart.swift
+++ b/Sources/AISDKProviderUtils/ContentPart.swift
@@ -32,7 +32,7 @@ public typealias ProviderOptions = SharedV3ProviderOptions
 /**
  Text content part of a prompt. It contains a string of text.
  */
-public struct TextPart: Sendable, Equatable {
+public struct TextPart: Sendable, Equatable, Codable {
     public let type: String = "text"
 
     /// The text content.
@@ -47,6 +47,23 @@ public struct TextPart: Sendable, Equatable {
         self.text = text
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, text, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        text = try container.decode(String.self, forKey: .text)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(text, forKey: .text)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Image Content
@@ -54,7 +71,7 @@ public struct TextPart: Sendable, Equatable {
 /**
  Image content part of a prompt. It contains an image.
  */
-public struct ImagePart: Sendable, Equatable {
+public struct ImagePart: Sendable, Equatable, Codable {
     public let type: String = "image"
 
     /// Image data. Can either be:
@@ -81,6 +98,25 @@ public struct ImagePart: Sendable, Equatable {
         self.mediaType = mediaType
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, image, mediaType, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        image = try container.decode(DataContentOrURL.self, forKey: .image)
+        mediaType = try container.decodeIfPresent(String.self, forKey: .mediaType)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(image, forKey: .image)
+        try container.encodeIfPresent(mediaType, forKey: .mediaType)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - File Content
@@ -88,7 +124,7 @@ public struct ImagePart: Sendable, Equatable {
 /**
  File content part of a prompt. It contains a file.
  */
-public struct FilePart: Sendable, Equatable {
+public struct FilePart: Sendable, Equatable, Codable {
     public let type: String = "file"
 
     /// File data. Can either be:
@@ -120,6 +156,27 @@ public struct FilePart: Sendable, Equatable {
         self.filename = filename
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, data, filename, mediaType, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        data = try container.decode(DataContentOrURL.self, forKey: .data)
+        filename = try container.decodeIfPresent(String.self, forKey: .filename)
+        mediaType = try container.decode(String.self, forKey: .mediaType)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(data, forKey: .data)
+        try container.encodeIfPresent(filename, forKey: .filename)
+        try container.encode(mediaType, forKey: .mediaType)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Reasoning Content
@@ -127,7 +184,7 @@ public struct FilePart: Sendable, Equatable {
 /**
  Reasoning content part of a prompt. It contains reasoning text.
  */
-public struct ReasoningPart: Sendable, Equatable {
+public struct ReasoningPart: Sendable, Equatable, Codable {
     public let type: String = "reasoning"
 
     /// The reasoning text.
@@ -142,6 +199,23 @@ public struct ReasoningPart: Sendable, Equatable {
         self.text = text
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, text, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        text = try container.decode(String.self, forKey: .text)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(text, forKey: .text)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Tool Call
@@ -149,7 +223,7 @@ public struct ReasoningPart: Sendable, Equatable {
 /**
  Tool call content part of a prompt. It contains a tool call (usually generated by the AI model).
  */
-public struct ToolCallPart: Sendable, Equatable {
+public struct ToolCallPart: Sendable, Equatable, Codable {
     public let type: String = "tool-call"
 
     /// ID of the tool call. This ID is used to match the tool call with the tool result.
@@ -182,6 +256,29 @@ public struct ToolCallPart: Sendable, Equatable {
         self.providerOptions = providerOptions
         self.providerExecuted = providerExecuted
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, toolCallId, toolName, input, providerOptions, providerExecuted
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        toolCallId = try container.decode(String.self, forKey: .toolCallId)
+        toolName = try container.decode(String.self, forKey: .toolName)
+        input = try container.decode(JSONValue.self, forKey: .input)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+        providerExecuted = try container.decodeIfPresent(Bool.self, forKey: .providerExecuted)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(toolCallId, forKey: .toolCallId)
+        try container.encode(toolName, forKey: .toolName)
+        try container.encode(input, forKey: .input)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+        try container.encodeIfPresent(providerExecuted, forKey: .providerExecuted)
+    }
 }
 
 // MARK: - Tool Result
@@ -189,7 +286,7 @@ public struct ToolCallPart: Sendable, Equatable {
 /**
  Tool result content part of a prompt. It contains the result of the tool call with the matching ID.
  */
-public struct ToolResultPart: Sendable, Equatable {
+public struct ToolResultPart: Sendable, Equatable, Codable {
     public let type: String = "tool-result"
 
     /// ID of the tool call that this result is associated with.
@@ -217,6 +314,27 @@ public struct ToolResultPart: Sendable, Equatable {
         self.output = output
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, toolCallId, toolName, output, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        toolCallId = try container.decode(String.self, forKey: .toolCallId)
+        toolName = try container.decode(String.self, forKey: .toolName)
+        output = try container.decode(LanguageModelV3ToolResultOutput.self, forKey: .output)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(toolCallId, forKey: .toolCallId)
+        try container.encode(toolName, forKey: .toolName)
+        try container.encode(output, forKey: .output)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Tool Approval
@@ -226,7 +344,7 @@ public struct ToolResultPart: Sendable, Equatable {
 
  Port of `@ai-sdk/provider-utils/types/tool-approval-request.ts`.
  */
-public struct ToolApprovalRequest: Sendable, Equatable {
+public struct ToolApprovalRequest: Sendable, Equatable, Codable {
     public let type: String = "tool-approval-request"
 
     /// ID of the tool approval.
@@ -239,6 +357,23 @@ public struct ToolApprovalRequest: Sendable, Equatable {
         self.approvalId = approvalId
         self.toolCallId = toolCallId
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, approvalId, toolCallId
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        approvalId = try container.decode(String.self, forKey: .approvalId)
+        toolCallId = try container.decode(String.self, forKey: .toolCallId)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(approvalId, forKey: .approvalId)
+        try container.encode(toolCallId, forKey: .toolCallId)
+    }
 }
 
 /**
@@ -246,7 +381,7 @@ public struct ToolApprovalRequest: Sendable, Equatable {
 
  Port of `@ai-sdk/provider-utils/types/tool-approval-response.ts`.
  */
-public struct ToolApprovalResponse: Sendable, Equatable {
+public struct ToolApprovalResponse: Sendable, Equatable, Codable {
     public let type: String = "tool-approval-response"
 
     /// ID of the tool approval.
@@ -267,5 +402,273 @@ public struct ToolApprovalResponse: Sendable, Equatable {
         self.approved = approved
         self.reason = reason
         self.providerExecuted = providerExecuted
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, approvalId, approved, reason, providerExecuted
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        approvalId = try container.decode(String.self, forKey: .approvalId)
+        approved = try container.decode(Bool.self, forKey: .approved)
+        reason = try container.decodeIfPresent(String.self, forKey: .reason)
+        providerExecuted = try container.decodeIfPresent(Bool.self, forKey: .providerExecuted)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(approvalId, forKey: .approvalId)
+        try container.encode(approved, forKey: .approved)
+        try container.encodeIfPresent(reason, forKey: .reason)
+        try container.encodeIfPresent(providerExecuted, forKey: .providerExecuted)
+    }
+}
+
+// MARK: - UserContentPart
+
+/**
+ Content part types allowed in user messages.
+ */
+public enum UserContentPart: Sendable, Equatable, Codable {
+    case text(TextPart)
+    case image(ImagePart)
+    case file(FilePart)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "text":
+            self = .text(try TextPart(from: decoder))
+        case "image":
+            self = .image(try ImagePart(from: decoder))
+        case "file":
+            self = .file(try FilePart(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown UserContentPart type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .text(let part):
+            try part.encode(to: encoder)
+        case .image(let part):
+            try part.encode(to: encoder)
+        case .file(let part):
+            try part.encode(to: encoder)
+        }
+    }
+}
+
+// MARK: - AssistantContentPart
+
+/**
+ Content part types allowed in assistant messages.
+ */
+public enum AssistantContentPart: Sendable, Equatable, Codable {
+    case text(TextPart)
+    case file(FilePart)
+    case reasoning(ReasoningPart)
+    case toolCall(ToolCallPart)
+    case toolResult(ToolResultPart)
+    case toolApprovalRequest(ToolApprovalRequest)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "text":
+            self = .text(try TextPart(from: decoder))
+        case "file":
+            self = .file(try FilePart(from: decoder))
+        case "reasoning":
+            self = .reasoning(try ReasoningPart(from: decoder))
+        case "tool-call":
+            self = .toolCall(try ToolCallPart(from: decoder))
+        case "tool-result":
+            self = .toolResult(try ToolResultPart(from: decoder))
+        case "tool-approval-request":
+            self = .toolApprovalRequest(try ToolApprovalRequest(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown AssistantContentPart type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .text(let part):
+            try part.encode(to: encoder)
+        case .file(let part):
+            try part.encode(to: encoder)
+        case .reasoning(let part):
+            try part.encode(to: encoder)
+        case .toolCall(let part):
+            try part.encode(to: encoder)
+        case .toolResult(let part):
+            try part.encode(to: encoder)
+        case .toolApprovalRequest(let part):
+            try part.encode(to: encoder)
+        }
+    }
+}
+
+// MARK: - ToolContentPart
+
+/**
+ Content part types allowed in tool messages.
+ */
+public enum ToolContentPart: Sendable, Equatable, Codable {
+    case toolResult(ToolResultPart)
+    case toolApprovalResponse(ToolApprovalResponse)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "tool-result":
+            self = .toolResult(try ToolResultPart(from: decoder))
+        case "tool-approval-response":
+            self = .toolApprovalResponse(try ToolApprovalResponse(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown ToolContentPart type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .toolResult(let part):
+            try part.encode(to: encoder)
+        case .toolApprovalResponse(let part):
+            try part.encode(to: encoder)
+        }
+    }
+}
+
+// MARK: - UserContent
+
+/**
+ Content of a user message. It can be a string or an array of text, image, and file parts.
+ */
+public enum UserContent: Sendable, Equatable, Codable {
+    /// Simple text content
+    case text(String)
+    /// Array of content parts (text, images, files)
+    case parts([UserContentPart])
+
+    private enum CodingKeys: String, CodingKey {
+        case type, value, parts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "text":
+            let value = try container.decode(String.self, forKey: .value)
+            self = .text(value)
+        case "parts":
+            let parts = try container.decode([UserContentPart].self, forKey: .parts)
+            self = .parts(parts)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown UserContent type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .text(let value):
+            try container.encode("text", forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .parts(let parts):
+            try container.encode("parts", forKey: .type)
+            try container.encode(parts, forKey: .parts)
+        }
+    }
+}
+
+// MARK: - AssistantContent
+
+/**
+ Content of an assistant message.
+ It can be a string or an array of text, file, reasoning, tool call, tool result, and approval request parts.
+ */
+public enum AssistantContent: Sendable, Equatable, Codable {
+    /// Simple text content
+    case text(String)
+    /// Array of content parts
+    case parts([AssistantContentPart])
+
+    private enum CodingKeys: String, CodingKey {
+        case type, value, parts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "text":
+            let value = try container.decode(String.self, forKey: .value)
+            self = .text(value)
+        case "parts":
+            let parts = try container.decode([AssistantContentPart].self, forKey: .parts)
+            self = .parts(parts)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown AssistantContent type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .text(let value):
+            try container.encode("text", forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .parts(let parts):
+            try container.encode("parts", forKey: .type)
+            try container.encode(parts, forKey: .parts)
+        }
     }
 }

--- a/Sources/AISDKProviderUtils/DataContent.swift
+++ b/Sources/AISDKProviderUtils/DataContent.swift
@@ -11,8 +11,61 @@ public enum DataContent: Sendable {
 }
 
 /// Union type for data content or URL inputs (matches upstream usage across packages).
-public enum DataContentOrURL: Sendable, Equatable {
+public enum DataContentOrURL: Sendable, Equatable, Codable {
     case data(Data)
     case string(String)
     case url(URL)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+        case value
+        case url
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "data":
+            let base64 = try container.decode(String.self, forKey: .data)
+            guard let data = Data(base64Encoded: base64) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .data,
+                    in: container,
+                    debugDescription: "Invalid base64 string"
+                )
+            }
+            self = .data(data)
+        case "string":
+            let value = try container.decode(String.self, forKey: .value)
+            self = .string(value)
+        case "url":
+            let url = try container.decode(URL.self, forKey: .url)
+            self = .url(url)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown DataContentOrURL type: \(type)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .data(let data):
+            try container.encode("data", forKey: .type)
+            try container.encode(data.base64EncodedString(), forKey: .data)
+        case .string(let value):
+            try container.encode("string", forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .url(let url):
+            try container.encode("url", forKey: .type)
+            try container.encode(url, forKey: .url)
+        }
+    }
 }

--- a/Sources/AISDKProviderUtils/ModelMessage.swift
+++ b/Sources/AISDKProviderUtils/ModelMessage.swift
@@ -28,7 +28,7 @@ import AISDKProvider
 
  Port of `@ai-sdk/provider-utils/types/system-model-message.ts`.
  */
-public struct SystemModelMessage: Sendable, Equatable {
+public struct SystemModelMessage: Sendable, Equatable, Codable {
     public let role: String = "system"
 
     /// System content (text only).
@@ -43,35 +43,33 @@ public struct SystemModelMessage: Sendable, Equatable {
         self.content = content
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decode(String.self, forKey: .content)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role, forKey: .role)
+        try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - User Message
-
-/**
- Content of a user message. It can be a string or an array of text, image, and file parts.
- */
-public enum UserContent: Sendable, Equatable {
-    /// Simple text content
-    case text(String)
-    /// Array of content parts (text, images, files)
-    case parts([UserContentPart])
-}
-
-/**
- Content part types allowed in user messages.
- */
-public enum UserContentPart: Sendable, Equatable {
-    case text(TextPart)
-    case image(ImagePart)
-    case file(FilePart)
-}
 
 /**
  A user message. It can contain text or a combination of text, images, and files.
 
  Port of `@ai-sdk/provider-utils/types/user-model-message.ts`.
  */
-public struct UserModelMessage: Sendable, Equatable {
+public struct UserModelMessage: Sendable, Equatable, Codable {
     public let role: String = "user"
 
     /// Content of the user message.
@@ -86,39 +84,33 @@ public struct UserModelMessage: Sendable, Equatable {
         self.content = content
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decode(UserContent.self, forKey: .content)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role, forKey: .role)
+        try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Assistant Message
-
-/**
- Content of an assistant message.
- It can be a string or an array of text, file, reasoning, tool call, tool result, and approval request parts.
- */
-public enum AssistantContent: Sendable, Equatable {
-    /// Simple text content
-    case text(String)
-    /// Array of content parts
-    case parts([AssistantContentPart])
-}
-
-/**
- Content part types allowed in assistant messages.
- */
-public enum AssistantContentPart: Sendable, Equatable {
-    case text(TextPart)
-    case file(FilePart)
-    case reasoning(ReasoningPart)
-    case toolCall(ToolCallPart)
-    case toolResult(ToolResultPart)
-    case toolApprovalRequest(ToolApprovalRequest)
-}
 
 /**
  An assistant message. It can contain text, tool calls, or a combination of text and tool calls.
 
  Port of `@ai-sdk/provider-utils/types/assistant-model-message.ts`.
  */
-public struct AssistantModelMessage: Sendable, Equatable {
+public struct AssistantModelMessage: Sendable, Equatable, Codable {
     public let role: String = "assistant"
 
     /// Content of the assistant message.
@@ -133,24 +125,33 @@ public struct AssistantModelMessage: Sendable, Equatable {
         self.content = content
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decode(AssistantContent.self, forKey: .content)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role, forKey: .role)
+        try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Tool Message
-
-/**
- Content part types allowed in tool messages.
- */
-public enum ToolContentPart: Sendable, Equatable {
-    case toolResult(ToolResultPart)
-    case toolApprovalResponse(ToolApprovalResponse)
-}
 
 /**
  A tool message. It contains the result of one or more tool calls.
 
  Port of `@ai-sdk/provider-utils/types/tool-model-message.ts`.
  */
-public struct ToolModelMessage: Sendable, Equatable {
+public struct ToolModelMessage: Sendable, Equatable, Codable {
     public let role: String = "tool"
 
     /// Content of the tool message (array of tool results and approval responses).
@@ -165,6 +166,23 @@ public struct ToolModelMessage: Sendable, Equatable {
         self.content = content
         self.providerOptions = providerOptions
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case role, content, providerOptions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        content = try container.decode([ToolContentPart].self, forKey: .content)
+        providerOptions = try container.decodeIfPresent(ProviderOptions.self, forKey: .providerOptions)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role, forKey: .role)
+        try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(providerOptions, forKey: .providerOptions)
+    }
 }
 
 // MARK: - Model Message Union
@@ -175,9 +193,48 @@ public struct ToolModelMessage: Sendable, Equatable {
 
  Port of `@ai-sdk/provider-utils/types/model-message.ts`.
  */
-public enum ModelMessage: Sendable, Equatable {
+public enum ModelMessage: Sendable, Equatable, Codable {
     case system(SystemModelMessage)
     case user(UserModelMessage)
     case assistant(AssistantModelMessage)
     case tool(ToolModelMessage)
+
+    private enum CodingKeys: String, CodingKey {
+        case role
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let role = try container.decode(String.self, forKey: .role)
+
+        switch role {
+        case "system":
+            self = .system(try SystemModelMessage(from: decoder))
+        case "user":
+            self = .user(try UserModelMessage(from: decoder))
+        case "assistant":
+            self = .assistant(try AssistantModelMessage(from: decoder))
+        case "tool":
+            self = .tool(try ToolModelMessage(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .role,
+                in: container,
+                debugDescription: "Unknown ModelMessage role: \(role)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .system(let message):
+            try message.encode(to: encoder)
+        case .user(let message):
+            try message.encode(to: encoder)
+        case .assistant(let message):
+            try message.encode(to: encoder)
+        case .tool(let message):
+            try message.encode(to: encoder)
+        }
+    }
 }

--- a/Tests/AISDKProviderUtilsTests/ModelMessageCodableTests.swift
+++ b/Tests/AISDKProviderUtilsTests/ModelMessageCodableTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import AISDKProviderUtils
+import AISDKProvider
+
+// MARK: - ModelMessage Codable Round-Trip Tests
+
+@Suite("ModelMessage Codable")
+struct ModelMessageCodableTests {
+
+    private func roundTrip(_ message: ModelMessage) throws -> ModelMessage {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(message)
+        return try JSONDecoder().decode(ModelMessage.self, from: data)
+    }
+
+    // MARK: - System
+
+    @Test func systemMessage() throws {
+        let msg = ModelMessage.system(SystemModelMessage(content: "You are helpful"))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    // MARK: - User
+
+    @Test func userTextMessage() throws {
+        let msg = ModelMessage.user(UserModelMessage(content: .text("Hello")))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func userPartsMessage() throws {
+        let msg = ModelMessage.user(UserModelMessage(content: .parts([
+            .text(TextPart(text: "Look at this")),
+            .image(ImagePart(image: .string("iVBOR"), mediaType: "image/png")),
+        ])))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    // MARK: - Assistant
+
+    @Test func assistantTextMessage() throws {
+        let msg = ModelMessage.assistant(AssistantModelMessage(content: .text("Hi there")))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func assistantWithReasoningAndToolCall() throws {
+        let msg = ModelMessage.assistant(AssistantModelMessage(content: .parts([
+            .reasoning(ReasoningPart(
+                text: "Let me think...",
+                providerOptions: ["anthropic": ["signature": .string("sig123")]]
+            )),
+            .text(TextPart(text: "I'll use a tool")),
+            .toolCall(ToolCallPart(
+                toolCallId: "call_1",
+                toolName: "bash",
+                input: .object(["command": .string("ls")])
+            )),
+        ])))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func assistantWithProviderExecutedToolResult() throws {
+        let msg = ModelMessage.assistant(AssistantModelMessage(content: .parts([
+            .toolResult(ToolResultPart(
+                toolCallId: "call_1",
+                toolName: "web_search",
+                output: .json(value: .object(["results": .array([])]))
+            )),
+        ])))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    // MARK: - Tool
+
+    @Test func toolResultMessage() throws {
+        let msg = ModelMessage.tool(ToolModelMessage(content: [
+            .toolResult(ToolResultPart(
+                toolCallId: "call_1",
+                toolName: "bash",
+                output: .text(value: "file1.txt\nfile2.txt")
+            )),
+        ]))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func toolResultWithJsonOutput() throws {
+        let msg = ModelMessage.tool(ToolModelMessage(content: [
+            .toolResult(ToolResultPart(
+                toolCallId: "call_1",
+                toolName: "mcp_tool",
+                output: .json(value: .object([
+                    "structuredContent": .object(["result": .string("OK")]),
+                    "content": .array([.object(["type": .string("text"), "text": .string("OK")])]),
+                    "isError": .bool(false),
+                ]))
+            )),
+        ]))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func toolResultWithContentParts() throws {
+        let msg = ModelMessage.tool(ToolModelMessage(content: [
+            .toolResult(ToolResultPart(
+                toolCallId: "call_1",
+                toolName: "screenshot",
+                output: .content(value: [
+                    .text(text: "Screenshot captured"),
+                    .media(data: "iVBOR", mediaType: "image/png"),
+                ])
+            )),
+        ]))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func toolResultWithErrorOutput() throws {
+        let msg = ModelMessage.tool(ToolModelMessage(content: [
+            .toolResult(ToolResultPart(
+                toolCallId: "call_1",
+                toolName: "bash",
+                output: .errorText(value: "Command failed with exit code 1")
+            )),
+        ]))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    // MARK: - Byte stability
+
+    @Test func encodingIsByteStableAcrossMultipleCalls() throws {
+        let msg = ModelMessage.assistant(AssistantModelMessage(content: .parts([
+            .reasoning(ReasoningPart(
+                text: "Thinking",
+                providerOptions: ["anthropic": ["signature": .string("sig")]]
+            )),
+            .text(TextPart(text: "Response")),
+            .toolCall(ToolCallPart(
+                toolCallId: "call_1",
+                toolName: "test",
+                input: .object(["zebra": .string("z"), "alpha": .string("a")])
+            )),
+        ])))
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        var results: [Data] = []
+        for _ in 0..<10 {
+            results.append(try encoder.encode(msg))
+        }
+
+        let first = results[0]
+        for (i, data) in results.enumerated().dropFirst() {
+            #expect(data == first, "Encoding \(i) differs from first")
+        }
+    }
+
+    // MARK: - Full conversation round-trip
+
+    @Test func fullConversationRoundTrip() throws {
+        let conversation: [ModelMessage] = [
+            .user(UserModelMessage(content: .text("Hello"))),
+            .assistant(AssistantModelMessage(content: .parts([
+                .reasoning(ReasoningPart(text: "User said hello")),
+                .text(TextPart(text: "Hi! Let me help you.")),
+                .toolCall(ToolCallPart(
+                    toolCallId: "call_1",
+                    toolName: "bash",
+                    input: .object(["command": .string("echo hello")])
+                )),
+            ]))),
+            .tool(ToolModelMessage(content: [
+                .toolResult(ToolResultPart(
+                    toolCallId: "call_1",
+                    toolName: "bash",
+                    output: .text(value: "hello")
+                )),
+            ])),
+            .assistant(AssistantModelMessage(content: .text("Done!"))),
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(conversation)
+        let decoded = try JSONDecoder().decode([ModelMessage].self, from: data)
+        #expect(decoded == conversation)
+    }
+}


### PR DESCRIPTION
## Description

Adds `Codable` conformance to `ModelMessage` for storage and constituent types along with round trip tests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

This is something natively supported already in JS.

## Testing

- [x] All tests pass (`swift test`)
- [x] Added tests for new functionality
- [ ] Verified upstream parity (if applicable)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [x] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)
