### PR TITLE
Fix Codable to match upstream JSON shapes for content and data types

### DIFF
--- a/Sources/AISDKProviderUtils/ContentPart.swift
+++ b/Sources/AISDKProviderUtils/ContentPart.swift
@@ -585,40 +585,35 @@ public enum UserContent: Sendable, Equatable, Codable {
     /// Array of content parts (text, images, files)
     case parts([UserContentPart])
 
-    private enum CodingKeys: String, CodingKey {
-        case type, value, parts
-    }
-
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
+        let container = try decoder.singleValueContainer()
 
-        switch type {
-        case "text":
-            let value = try container.decode(String.self, forKey: .value)
-            self = .text(value)
-        case "parts":
-            let parts = try container.decode([UserContentPart].self, forKey: .parts)
-            self = .parts(parts)
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown UserContent type: \(type)"
-            )
+        if let string = try? container.decode(String.self) {
+            self = .text(string)
+            return
         }
+
+        if let parts = try? container.decode([UserContentPart].self) {
+            self = .parts(parts)
+            return
+        }
+
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Cannot decode UserContent"
+            )
+        )
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.singleValueContainer()
 
         switch self {
         case .text(let value):
-            try container.encode("text", forKey: .type)
-            try container.encode(value, forKey: .value)
+            try container.encode(value)
         case .parts(let parts):
-            try container.encode("parts", forKey: .type)
-            try container.encode(parts, forKey: .parts)
+            try container.encode(parts)
         }
     }
 }
@@ -635,40 +630,35 @@ public enum AssistantContent: Sendable, Equatable, Codable {
     /// Array of content parts
     case parts([AssistantContentPart])
 
-    private enum CodingKeys: String, CodingKey {
-        case type, value, parts
-    }
-
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
+        let container = try decoder.singleValueContainer()
 
-        switch type {
-        case "text":
-            let value = try container.decode(String.self, forKey: .value)
-            self = .text(value)
-        case "parts":
-            let parts = try container.decode([AssistantContentPart].self, forKey: .parts)
-            self = .parts(parts)
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown AssistantContent type: \(type)"
-            )
+        if let string = try? container.decode(String.self) {
+            self = .text(string)
+            return
         }
+
+        if let parts = try? container.decode([AssistantContentPart].self) {
+            self = .parts(parts)
+            return
+        }
+
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Cannot decode AssistantContent"
+            )
+        )
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.singleValueContainer()
 
         switch self {
         case .text(let value):
-            try container.encode("text", forKey: .type)
-            try container.encode(value, forKey: .value)
+            try container.encode(value)
         case .parts(let parts):
-            try container.encode("parts", forKey: .type)
-            try container.encode(parts, forKey: .parts)
+            try container.encode(parts)
         }
     }
 }

--- a/Sources/AISDKProviderUtils/DataContent.swift
+++ b/Sources/AISDKProviderUtils/DataContent.swift
@@ -16,56 +16,41 @@ public enum DataContentOrURL: Sendable, Equatable, Codable {
     case string(String)
     case url(URL)
 
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case data
-        case value
-        case url
-    }
-
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
+        let container = try decoder.singleValueContainer()
 
-        switch type {
-        case "data":
-            let base64 = try container.decode(String.self, forKey: .data)
-            guard let data = Data(base64Encoded: base64) else {
-                throw DecodingError.dataCorruptedError(
-                    forKey: .data,
-                    in: container,
-                    debugDescription: "Invalid base64 string"
-                )
+        if let string = try? container.decode(String.self) {
+            if let url = URL(string: string), url.scheme != nil {
+                self = .url(url)
+            } else {
+                self = .string(string)
             }
-            self = .data(data)
-        case "string":
-            let value = try container.decode(String.self, forKey: .value)
-            self = .string(value)
-        case "url":
-            let url = try container.decode(URL.self, forKey: .url)
-            self = .url(url)
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown DataContentOrURL type: \(type)"
-            )
+            return
         }
+
+        if let data = try? container.decode(Data.self) {
+            self = .data(data)
+            return
+        }
+
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Cannot decode DataContentOrURL"
+            )
+        )
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.singleValueContainer()
 
         switch self {
-        case .data(let data):
-            try container.encode("data", forKey: .type)
-            try container.encode(data.base64EncodedString(), forKey: .data)
         case .string(let value):
-            try container.encode("string", forKey: .type)
-            try container.encode(value, forKey: .value)
+            try container.encode(value)
         case .url(let url):
-            try container.encode("url", forKey: .type)
-            try container.encode(url, forKey: .url)
+            try container.encode(url.absoluteString)
+        case .data(let data):
+            try container.encode(data.base64EncodedString())
         }
     }
 }

--- a/Tests/AISDKProviderUtilsTests/ModelMessageCodableTests.swift
+++ b/Tests/AISDKProviderUtilsTests/ModelMessageCodableTests.swift
@@ -194,4 +194,206 @@ struct ModelMessageCodableTests {
         let decoded = try JSONDecoder().decode([ModelMessage].self, from: data)
         #expect(decoded == conversation)
     }
+
+    // MARK: - JSON shape snapshot
+
+    @Test func fullConversationEncodesToUpstreamShape() throws {
+        let conversation: [ModelMessage] = [
+            .system(SystemModelMessage(content: "You are helpful")),
+            .user(UserModelMessage(content: .text("Hello"))),
+            .user(UserModelMessage(content: .parts([
+                .text(TextPart(text: "Look at this")),
+                .image(ImagePart(image: .string("iVBOR"), mediaType: "image/png")),
+            ]))),
+            .assistant(AssistantModelMessage(content: .text("Sure!"))),
+            .assistant(AssistantModelMessage(content: .parts([
+                .reasoning(ReasoningPart(text: "Let me think")),
+                .text(TextPart(text: "I'll use a tool")),
+                .toolCall(ToolCallPart(
+                    toolCallId: "call_1", toolName: "bash",
+                    input: .object(["command": .string("ls")])
+                )),
+            ]))),
+            .tool(ToolModelMessage(content: [
+                .toolResult(ToolResultPart(
+                    toolCallId: "call_1", toolName: "bash",
+                    output: .text(value: "file1.txt")
+                )),
+            ])),
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        let data = try encoder.encode(conversation)
+        let json = String(data: data, encoding: .utf8)!
+
+        // Verify the JSON matches the upstream TypeScript shape exactly:
+        // - Messages are objects with "role" + "content"
+        // - User text content is a bare string, not {"type":"text","value":"..."}
+        // - User parts content is a bare array, not {"type":"parts","parts":[...]}
+        // - Image data is a bare string, not {"type":"string","value":"..."}
+        // - Part objects have "type" discriminator fields
+        // - Tool call type is "tool-call" (hyphenated)
+        // - Tool result type is "tool-result" (hyphenated)
+        let expected = """
+        [
+          {
+            "content" : "You are helpful",
+            "role" : "system"
+          },
+          {
+            "content" : "Hello",
+            "role" : "user"
+          },
+          {
+            "content" : [
+              {
+                "text" : "Look at this",
+                "type" : "text"
+              },
+              {
+                "image" : "iVBOR",
+                "mediaType" : "image\\/png",
+                "type" : "image"
+              }
+            ],
+            "role" : "user"
+          },
+          {
+            "content" : "Sure!",
+            "role" : "assistant"
+          },
+          {
+            "content" : [
+              {
+                "text" : "Let me think",
+                "type" : "reasoning"
+              },
+              {
+                "text" : "I'll use a tool",
+                "type" : "text"
+              },
+              {
+                "input" : {
+                  "command" : "ls"
+                },
+                "toolCallId" : "call_1",
+                "toolName" : "bash",
+                "type" : "tool-call"
+              }
+            ],
+            "role" : "assistant"
+          },
+          {
+            "content" : [
+              {
+                "output" : {
+                  "type" : "text",
+                  "value" : "file1.txt"
+                },
+                "toolCallId" : "call_1",
+                "toolName" : "bash",
+                "type" : "tool-result"
+              }
+            ],
+            "role" : "tool"
+          }
+        ]
+        """
+        #expect(json == expected)
+    }
+
+    // MARK: - Upstream JSON shape decoding
+
+    @Test func decodesUserMessageWithStringContent() throws {
+        let json = """
+        {"role":"user","content":"Hello"}
+        """
+        let msg = try JSONDecoder().decode(ModelMessage.self, from: Data(json.utf8))
+        guard case .user(let user) = msg,
+              case .text(let text) = user.content else {
+            Issue.record("Expected user message with text content")
+            return
+        }
+        #expect(text == "Hello")
+    }
+
+    @Test func decodesUserMessageWithPartsArray() throws {
+        let json = """
+        {"role":"user","content":[{"type":"text","text":"Look"},{"type":"image","image":"iVBOR","mediaType":"image/png"}]}
+        """
+        let msg = try JSONDecoder().decode(ModelMessage.self, from: Data(json.utf8))
+        guard case .user(let user) = msg,
+              case .parts(let parts) = user.content else {
+            Issue.record("Expected user message with parts content")
+            return
+        }
+        #expect(parts.count == 2)
+    }
+
+    @Test func decodesAssistantMessageWithStringContent() throws {
+        let json = """
+        {"role":"assistant","content":"Hi there"}
+        """
+        let msg = try JSONDecoder().decode(ModelMessage.self, from: Data(json.utf8))
+        guard case .assistant(let asst) = msg,
+              case .text(let text) = asst.content else {
+            Issue.record("Expected assistant message with text content")
+            return
+        }
+        #expect(text == "Hi there")
+    }
+
+    @Test func decodesImagePartWithDirectStringData() throws {
+        let json = """
+        {"role":"user","content":[{"type":"image","image":"iVBORbase64data","mediaType":"image/png"}]}
+        """
+        let msg = try JSONDecoder().decode(ModelMessage.self, from: Data(json.utf8))
+        guard case .user(let user) = msg,
+              case .parts(let parts) = user.content,
+              case .image(let imagePart) = parts.first,
+              case .string(let data) = imagePart.image else {
+            Issue.record("Expected image part with string data")
+            return
+        }
+        #expect(data == "iVBORbase64data")
+    }
+
+    @Test func encodesUserTextContentAsBareString() throws {
+        let msg = ModelMessage.user(UserModelMessage(content: .text("Hello")))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(msg)
+        let json = try JSONDecoder().decode([String: JSONValue].self, from: data)
+        guard case .string(let content) = json["content"] else {
+            Issue.record("Expected content to be a bare string, got \(String(describing: json["content"]))")
+            return
+        }
+        #expect(content == "Hello")
+    }
+
+    @Test func encodesUserPartsContentAsBareArray() throws {
+        let msg = ModelMessage.user(UserModelMessage(content: .parts([
+            .text(TextPart(text: "Look")),
+        ])))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(msg)
+        let json = try JSONDecoder().decode([String: JSONValue].self, from: data)
+        guard case .array = json["content"] else {
+            Issue.record("Expected content to be a bare array, got \(String(describing: json["content"]))")
+            return
+        }
+    }
+
+    @Test func encodesImageDataAsBareString() throws {
+        let msg = ModelMessage.user(UserModelMessage(content: .parts([
+            .image(ImagePart(image: .string("iVBOR"), mediaType: "image/png")),
+        ])))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(msg)
+        let str = String(data: data, encoding: .utf8)!
+        #expect(str.contains("\"image\":\"iVBOR\""))
+    }
 }


### PR DESCRIPTION
Follow-on from my last PR to address review feedback:
https://github.com/teunlao/swift-ai-sdk/pull/22

UserContent/AssistantContent now encode as the upstream string|array union: bare string for text content, bare array for parts. Previously used tagged wrapper objects ({type, value/parts}) which diverged from the public schema and broke decoding of upstream-format JSON like {"role":"user","content":"Hello"}.

DataContentOrURL now encodes as a direct string value (same pattern as LanguageModelV3DataContent) instead of wrapper objects. Strings encode as bare strings, URLs as their absoluteString, Data as base64.

Added 7 upstream-shape compatibility tests covering:
- Decoding user/assistant messages with bare string content
- Decoding user messages with bare array content
- Decoding image parts with direct string data
- Verifying encoding produces bare strings/arrays, not wrappers