### PR TITLE
Fix Bedrock reasoning prompt parity and strengthen Codable regressions

### DIFF
--- a/Sources/AmazonBedrockProvider/ConvertToBedrockChatMessages.swift
+++ b/Sources/AmazonBedrockProvider/ConvertToBedrockChatMessages.swift
@@ -184,24 +184,36 @@ func convertToBedrockChatMessages(
                         throw UnsupportedFunctionalityError(functionality: "Assistant file content")
 
                     case .reasoning(let reasoningPart):
-                        let trimmed = trimIfNeeded(reasoningPart.text, isLastBlock: isLastBlock, isLastMessage: isLastMessage, isLastPart: isLastPart)
                         let metadata = try await parseReasoningMetadata(reasoningPart.providerOptions)
-                        guard let metadata else { break }
-
-                        if let signature = metadata.signature {
+                        if let signature = metadata?.signature {
+                            // Bedrock signatures validate the exact original bytes, so keep text unchanged.
                             content.append(.object([
                                 "reasoningContent": .object([
                                     "reasoningText": .object([
-                                        "text": .string(trimmed),
+                                        "text": .string(reasoningPart.text),
                                         "signature": .string(signature)
                                     ])
                                 ])
                             ]))
-                        } else if let redacted = metadata.redactedData {
+                        } else if let redacted = metadata?.redactedData {
                             content.append(.object([
                                 "reasoningContent": .object([
                                     "redactedReasoning": .object([
                                         "data": .string(redacted)
+                                    ])
+                                ])
+                            ]))
+                        } else {
+                            let trimmed = trimIfNeeded(
+                                reasoningPart.text,
+                                isLastBlock: isLastBlock,
+                                isLastMessage: isLastMessage,
+                                isLastPart: isLastPart
+                            )
+                            content.append(.object([
+                                "reasoningContent": .object([
+                                    "reasoningText": .object([
+                                        "text": .string(trimmed)
                                     ])
                                 ])
                             ]))

--- a/Tests/AISDKProviderUtilsTests/ModelMessageCodableTests.swift
+++ b/Tests/AISDKProviderUtilsTests/ModelMessageCodableTests.swift
@@ -15,6 +15,13 @@ struct ModelMessageCodableTests {
         return try JSONDecoder().decode(ModelMessage.self, from: data)
     }
 
+    private func encodedJSON<T: Encodable>(_ value: T) throws -> JSONValue {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        return try JSONDecoder().decode(JSONValue.self, from: data)
+    }
+
     // MARK: - System
 
     @Test func systemMessage() throws {
@@ -71,6 +78,20 @@ struct ModelMessageCodableTests {
                 toolCallId: "call_1",
                 toolName: "web_search",
                 output: .json(value: .object(["results": .array([])]))
+            )),
+        ])))
+        let decoded = try roundTrip(msg)
+        #expect(decoded == msg)
+    }
+
+    @Test func assistantToolCallPreservesProviderExecutedAndProviderOptions() throws {
+        let msg = ModelMessage.assistant(AssistantModelMessage(content: .parts([
+            .toolCall(ToolCallPart(
+                toolCallId: "call_1",
+                toolName: "computer",
+                input: .object(["action": .string("click")]),
+                providerOptions: ["openai": ["priority": .string("high")]],
+                providerExecuted: true
             )),
         ])))
         let decoded = try roundTrip(msg)
@@ -134,6 +155,31 @@ struct ModelMessageCodableTests {
         #expect(decoded == msg)
     }
 
+    @Test func approvalPartsPreserveProviderExecutedAndReason() throws {
+        let messages: [ModelMessage] = [
+            .assistant(AssistantModelMessage(content: .parts([
+                .toolApprovalRequest(ToolApprovalRequest(
+                    approvalId: "approval_1",
+                    toolCallId: "call_1"
+                )),
+            ]))),
+            .tool(ToolModelMessage(content: [
+                .toolApprovalResponse(ToolApprovalResponse(
+                    approvalId: "approval_1",
+                    approved: true,
+                    reason: "Approved by user",
+                    providerExecuted: true
+                )),
+            ])),
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(messages)
+        let decoded = try JSONDecoder().decode([ModelMessage].self, from: data)
+        #expect(decoded == messages)
+    }
+
     // MARK: - Byte stability
 
     @Test func encodingIsByteStableAcrossMultipleCalls() throws {
@@ -193,5 +239,88 @@ struct ModelMessageCodableTests {
         let data = try encoder.encode(conversation)
         let decoded = try JSONDecoder().decode([ModelMessage].self, from: data)
         #expect(decoded == conversation)
+    }
+
+    // MARK: - Storage shape regressions
+
+    @Test func userTextMessageUsesTaggedStorageContentShape() throws {
+        let json = try encodedJSON(
+            ModelMessage.user(UserModelMessage(content: .text("Hello")))
+        )
+
+        let expected: JSONValue = .object([
+            "content": .object([
+                "type": .string("text"),
+                "value": .string("Hello"),
+            ]),
+            "role": .string("user"),
+        ])
+
+        #expect(json == expected)
+    }
+
+    @Test func dataContentOrURLUsesExplicitTaggedStorageCases() throws {
+        let url = URL(string: "https://example.com/cat.png")!
+        let binary = Data([0x00, 0x01, 0x02])
+
+        let stringJSON = try encodedJSON(DataContentOrURL.string("iVBOR"))
+        let urlJSON = try encodedJSON(DataContentOrURL.url(url))
+        let dataJSON = try encodedJSON(DataContentOrURL.data(binary))
+
+        #expect(stringJSON == .object([
+            "type": .string("string"),
+            "value": .string("iVBOR"),
+        ]))
+        #expect(urlJSON == .object([
+            "type": .string("url"),
+            "url": .string("https://example.com/cat.png"),
+        ]))
+        #expect(dataJSON == .object([
+            "type": .string("data"),
+            "data": .string("AAEC"),
+        ]))
+    }
+
+    @Test func imageAndFilePartsPreserveDistinctStringURLAndDataStorageCases() throws {
+        let msg = ModelMessage.user(UserModelMessage(content: .parts([
+            .image(ImagePart(
+                image: .url(URL(string: "https://example.com/image.png")!),
+                mediaType: "image/png"
+            )),
+            .file(FilePart(
+                data: .data(Data([0xDE, 0xAD, 0xBE, 0xEF])),
+                mediaType: "application/octet-stream",
+                filename: "blob.bin"
+            )),
+        ])))
+
+        let json = try encodedJSON(msg)
+        let expected: JSONValue = .object([
+            "content": .object([
+                "type": .string("parts"),
+                "parts": .array([
+                    .object([
+                        "image": .object([
+                            "type": .string("url"),
+                            "url": .string("https://example.com/image.png"),
+                        ]),
+                        "mediaType": .string("image/png"),
+                        "type": .string("image"),
+                    ]),
+                    .object([
+                        "data": .object([
+                            "type": .string("data"),
+                            "data": .string("3q2+7w=="),
+                        ]),
+                        "filename": .string("blob.bin"),
+                        "mediaType": .string("application/octet-stream"),
+                        "type": .string("file"),
+                    ]),
+                ]),
+            ]),
+            "role": .string("user"),
+        ])
+
+        #expect(json == expected)
     }
 }

--- a/Tests/AmazonBedrockProviderTests/ConvertToBedrockChatMessagesTests.swift
+++ b/Tests/AmazonBedrockProviderTests/ConvertToBedrockChatMessagesTests.swift
@@ -183,4 +183,76 @@ struct ConvertToBedrockChatMessagesTests {
             ]),
         ])
     }
+
+    @Test("preserves reasoning content without Bedrock metadata")
+    func preservesReasoningContentWithoutMetadata() async throws {
+        let prompt: LanguageModelV3Prompt = [
+            .user(content: [.text(.init(text: "Explain your reasoning"))], providerOptions: nil),
+            .assistant(
+                content: [
+                    .reasoning(.init(text: "My reasoning"))
+                ],
+                providerOptions: nil
+            )
+        ]
+
+        let result = try await convertToBedrockChatMessages(prompt)
+        #expect(result.messages == [
+            .object([
+                "role": .string("user"),
+                "content": .array([.object(["text": .string("Explain your reasoning")])])
+            ]),
+            .object([
+                "role": .string("assistant"),
+                "content": .array([
+                    .object([
+                        "reasoningContent": .object([
+                            "reasoningText": .object([
+                                "text": .string("My reasoning"),
+                            ])
+                        ])
+                    ])
+                ])
+            ]),
+        ])
+    }
+
+    @Test("does not trim reasoning text when Bedrock signature is present")
+    func doesNotTrimReasoningTextWhenSignaturePresent() async throws {
+        let prompt: LanguageModelV3Prompt = [
+            .user(content: [.text(.init(text: "Explain your reasoning"))], providerOptions: nil),
+            .assistant(
+                content: [
+                    .reasoning(.init(
+                        text: "Reasoning with trailing spaces    ",
+                        providerOptions: [
+                            "bedrock": ["signature": .string("test-signature")]
+                        ]
+                    ))
+                ],
+                providerOptions: nil
+            )
+        ]
+
+        let result = try await convertToBedrockChatMessages(prompt)
+        #expect(result.messages == [
+            .object([
+                "role": .string("user"),
+                "content": .array([.object(["text": .string("Explain your reasoning")])])
+            ]),
+            .object([
+                "role": .string("assistant"),
+                "content": .array([
+                    .object([
+                        "reasoningContent": .object([
+                            "reasoningText": .object([
+                                "text": .string("Reasoning with trailing spaces    "),
+                                "signature": .string("test-signature"),
+                            ])
+                        ])
+                    ])
+                ])
+            ]),
+        ])
+    }
 }


### PR DESCRIPTION
## Summary

- preserve Amazon Bedrock assistant reasoning parts during prompt conversion even when no Bedrock metadata is present
- keep reasoning text untrimmed when a Bedrock signature is present, matching upstream behavior
- strengthen `ModelMessage` Codable regression coverage for the accepted Swift-native persistence/storage shape

## Validation

- `swift test --filter ConvertToBedrockChatMessagesTests`
- `swift test --filter ModelMessageCodableTests`