### PR TITLE
Bunch/tool cancellation

### DIFF
--- a/Sources/SwiftAISDK/GenerateText/StreamTextActor.swift
+++ b/Sources/SwiftAISDK/GenerateText/StreamTextActor.swift
@@ -111,6 +111,13 @@ actor StreamTextActor {
     // This mirrors the upstream `stopStream` hook used by transforms.
     func requestStop() async {
         externalStopRequested = true
+
+        // Cancel all in-flight tool tasks so cancellation propagates into
+        // tool execute closures (e.g. via withTaskCancellationHandler)
+        for (_, task) in inFlightToolTasks {
+            task.cancel()
+        }
+
         // Emit `.abort` immediately to notify consumers, but keep streams open
         // until the provider finishes so we can still publish a final `.finish`.
         if !terminated && !abortEmitted {

--- a/Tests/SwiftAISDKTests/GenerateText/StreamTextConcurrencyTests.swift
+++ b/Tests/SwiftAISDKTests/GenerateText/StreamTextConcurrencyTests.swift
@@ -181,4 +181,68 @@ struct StreamTextConcurrencyTests {
             "Tool calls ran sequentially — an end arrived before both starts. Events: \(events)"
         )
     }
+
+    @Test("stop() cancels in-flight tool tasks",
+          .timeLimit(.minutes(1)))
+    func stopCancelsInFlightToolTasks() async throws {
+        let toolStarted = Flag()
+        let toolCancelled = Flag()
+
+        let stream = AsyncThrowingStream<LanguageModelV3StreamPart, Error> { c in
+            _ = Task {
+                c.yield(.streamStart(warnings: []))
+                c.yield(.responseMetadata(id: "s1", modelId: "mock-model", timestamp: Date(timeIntervalSince1970: 0)))
+                c.yield(.toolCall(LanguageModelV3ToolCall(
+                    toolCallId: "call-1",
+                    toolName: "blocking_tool",
+                    input: "{}",
+                    providerExecuted: false,
+                    providerMetadata: nil
+                )))
+                c.yield(.finish(
+                    finishReason: LanguageModelV3FinishReason(unified: .toolCalls),
+                    usage: defaultUsage,
+                    providerMetadata: nil
+                ))
+                c.finish()
+            }
+        }
+
+        let tools: ToolSet = [
+            "blocking_tool": Tool(
+                description: "Blocks until cancelled",
+                inputSchema: FlexibleSchema(jsonSchema(.object(["type": .string("object")]))),
+                needsApproval: .never,
+                execute: { _, _ in
+                    await toolStarted.set()
+                    // Sleep for a long time — stop() should cancel this task,
+                    // causing Task.sleep to throw CancellationError
+                    do {
+                        try await Task.sleep(for: .seconds(60))
+                    } catch is CancellationError {
+                        await toolCancelled.set()
+                    }
+                    return .value(.null)
+                }
+            )
+        ]
+
+        let model = MockLanguageModelV3(doStream: .singleValue(LanguageModelV3StreamResult(stream: stream)))
+        let result: DefaultStreamTextResult<JSONValue, JSONValue> = try streamText(
+            model: .v3(model),
+            prompt: "hello",
+            tools: tools
+        )
+
+        // Wait for the tool execute closure to start running
+        let started = await waitUntil(2.0) { await toolStarted.get() }
+        #expect(started, "Tool execute closure should have started")
+
+        result.stop()
+
+        // The tool task should be cancelled promptly — if stop() doesn't
+        // cancel in-flight tool tasks, this will hang for ~60 seconds
+        let cancelled = await waitUntil(2.0) { await toolCancelled.get() }
+        #expect(cancelled, "Tool task should be cancelled when stop() is called")
+    }
 }


### PR DESCRIPTION
## Description

`requestStop()` (called by `stop()`) sets `externalStopRequested` and emits `.abort`, but never cancels the `inFlightToolTasks` — unstructured `Task`s spawned for each tool execute closure. These tasks continue running indefinitely even after `stop()` is called, meaning long-running tool operations (e.g., a bash process running `sleep 30`) are never interrupted.

This adds cancellation of all `inFlightToolTasks` in `requestStop()` so that Swift cooperative cancellation propagates into tool execute closures. Tools that use `withTaskCancellationHandler` (e.g., to kill spawned processes) will now have their `onCancel` handlers fire when `stop()` is called.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

N/A — this is a Swift-specific concurrency fix. The TypeScript SDK uses a different execution model for tools and does not have this issue.

- Upstream file(s): N/A
- Upstream commit: N/A

## Testing

- [x] All tests pass (`swift test`) — 3712 tests in 416 suites
- [x] Added tests for new functionality
- [ ] Verified upstream parity (if applicable)

New test: `stopCancelsInFlightToolTasks` in `StreamTextConcurrencyTests.swift`
- Mock provider emits a tool call; the tool's execute closure sleeps for 60 seconds
- `stop()` is called while the tool is sleeping
- Verifies the tool task is cancelled within 2 seconds (previously hung for 60s)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [ ] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)

## Additional Notes

Tool execute closures must cooperatively check for cancellation (via `Task.isCancelled`, `try await Task.sleep`, or `withTaskCancellationHandler`) to respond to `stop()`. This is consistent with Swift's cooperative cancellation model — `task.cancel()` sets the cancellation flag but does not forcibly terminate the task.
