### PR TITLE
Opus 4.7: Add xhigh effort level to AnthropicEffort enum

### DIFF
--- a/Sources/AnthropicProvider/AnthropicMessagesLanguageModel.swift
+++ b/Sources/AnthropicProvider/AnthropicMessagesLanguageModel.swift
@@ -721,15 +721,23 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
             switch thinkingMode {
             case .enabled:
                 if let budget = thinkingBudget {
-                    args["thinking"] = .object([
+                    var thinkingPayload: [String: JSONValue] = [
                         "type": .string("enabled"),
                         "budget_tokens": .number(Double(budget)),
-                    ])
+                    ]
+                    if let display = anthropicOptions?.thinking?.display {
+                        thinkingPayload["display"] = .string(display.rawValue)
+                    }
+                    args["thinking"] = .object(thinkingPayload)
                     args["max_tokens"] = .number(Double(maxTokens + budget))
                 }
             case .adaptive:
                 // Adaptive mode: Claude dynamically decides when and how much to think
-                args["thinking"] = .object(["type": .string("adaptive")])
+                var thinkingPayload: [String: JSONValue] = ["type": .string("adaptive")]
+                if let display = anthropicOptions?.thinking?.display {
+                    thinkingPayload["display"] = .string(display.rawValue)
+                }
+                args["thinking"] = .object(thinkingPayload)
             default:
                 break
             }

--- a/Sources/AnthropicProvider/AnthropicMessagesLanguageModel.swift
+++ b/Sources/AnthropicProvider/AnthropicMessagesLanguageModel.swift
@@ -769,7 +769,6 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
         // Effort
         if let effort = anthropicOptions?.effort {
             args["output_config"] = .object(["effort": .string(effort.rawValue)])
-            betas.insert("effort-2025-11-24")
         }
 
         // Speed (fast mode, Opus 4.6 only)

--- a/Sources/AnthropicProvider/AnthropicProviderOptions.swift
+++ b/Sources/AnthropicProvider/AnthropicProviderOptions.swift
@@ -57,6 +57,7 @@ public enum AnthropicEffort: String, Sendable, Equatable {
     case low
     case medium
     case high
+    case xhigh
     /// Opus 4.6 only. Claude always thinks with no constraints on thinking depth.
     case max
 }
@@ -568,7 +569,7 @@ public let anthropicProviderOptionsSchema = FlexibleSchema(
                 if let effortValue = dict["effort"], effortValue != .null {
                     guard case .string(let raw) = effortValue,
                           let effort = AnthropicEffort(rawValue: raw) else {
-                        let error = SchemaValidationIssuesError(vendor: "anthropic", issues: "effort must be 'low', 'medium', 'high', or 'max'")
+                        let error = SchemaValidationIssuesError(vendor: "anthropic", issues: "effort must be 'low', 'medium', 'high', 'xhigh', or 'max'")
                         return .failure(error: TypeValidationError.wrap(value: effortValue, cause: error))
                     }
                     options.effort = effort

--- a/Sources/AnthropicProvider/AnthropicProviderOptions.swift
+++ b/Sources/AnthropicProvider/AnthropicProviderOptions.swift
@@ -38,12 +38,25 @@ public struct AnthropicThinkingOptions: Sendable, Equatable {
         case adaptive
     }
 
+    /// Controls how thinking content is returned in API responses.
+    /// - `summarized`: thinking blocks contain summarized text. Default on
+    ///   Claude Opus 4.6, Sonnet 4.6, and earlier Claude 4 models.
+    /// - `omitted`: thinking blocks are returned with an empty `thinking` field.
+    ///   The `signature` is still populated for multi-turn continuity. Default
+    ///   on Claude Opus 4.7 and Claude Mythos Preview.
+    public enum Display: String, Sendable, Equatable {
+        case summarized
+        case omitted
+    }
+
     public var type: Mode
     public var budgetTokens: Int?
+    public var display: Display?
 
-    public init(type: Mode, budgetTokens: Int? = nil) {
+    public init(type: Mode, budgetTokens: Int? = nil, display: Display? = nil) {
         self.type = type
         self.budgetTokens = budgetTokens
+        self.display = display
     }
 }
 
@@ -420,7 +433,17 @@ public let anthropicProviderOptionsSchema = FlexibleSchema(
                         budget = intValue
                     }
 
-                    options.thinking = AnthropicThinkingOptions(type: mode, budgetTokens: budget)
+                    var display: AnthropicThinkingOptions.Display?
+                    if let displayValue = thinkingDict["display"], displayValue != .null {
+                        guard case .string(let raw) = displayValue,
+                              let parsed = AnthropicThinkingOptions.Display(rawValue: raw) else {
+                            let error = SchemaValidationIssuesError(vendor: "anthropic", issues: "thinking.display must be 'summarized' or 'omitted'")
+                            return .failure(error: TypeValidationError.wrap(value: displayValue, cause: error))
+                        }
+                        display = parsed
+                    }
+
+                    options.thinking = AnthropicThinkingOptions(type: mode, budgetTokens: budget, display: display)
                 }
 
                 options.disableParallelToolUse = try parseOptionalBool(dict, key: "disableParallelToolUse")

--- a/Tests/AnthropicProviderTests/AnthropicMessagesLanguageModelProviderOptionsRequestTests.swift
+++ b/Tests/AnthropicProviderTests/AnthropicMessagesLanguageModelProviderOptionsRequestTests.swift
@@ -442,6 +442,115 @@ struct AnthropicMessagesLanguageModelProviderOptionsRequestTests {
         #expect(json?["top_p"] == nil)
     }
 
+    @Test("sends thinking.display when set on adaptive thinking")
+    func sendsAdaptiveThinkingWithDisplay() async throws {
+        let capture = RequestCapture()
+        let responseData = try makeProviderOptionsTestResponseData(model: "claude-opus-4-7")
+
+        let fetch: FetchFunction = { request in
+            await capture.store(request)
+            return FetchResponse(body: .data(responseData), urlResponse: makeProviderOptionsTestHTTPResponse())
+        }
+
+        let model = AnthropicMessagesLanguageModel(
+            modelId: .init(rawValue: "claude-opus-4-7"),
+            config: makeProviderOptionsTestConfig(fetch: fetch)
+        )
+
+        _ = try await model.doGenerate(options: .init(
+            prompt: providerOptionsTestPrompt,
+            providerOptions: [
+                "anthropic": [
+                    "thinking": .object([
+                        "type": .string("adaptive"),
+                        "display": .string("summarized"),
+                    ])
+                ]
+            ]
+        ))
+
+        let json = decodeRequestJSON(await capture.current())
+        if let thinking = json?["thinking"] as? [String: Any] {
+            #expect(thinking["type"] as? String == "adaptive")
+            #expect(thinking["display"] as? String == "summarized")
+        } else {
+            Issue.record("Expected thinking payload")
+        }
+    }
+
+    @Test("sends thinking.display when set on enabled thinking")
+    func sendsEnabledThinkingWithDisplay() async throws {
+        let capture = RequestCapture()
+        let responseData = try makeProviderOptionsTestResponseData(model: "claude-sonnet-4-5-20250929")
+
+        let fetch: FetchFunction = { request in
+            await capture.store(request)
+            return FetchResponse(body: .data(responseData), urlResponse: makeProviderOptionsTestHTTPResponse())
+        }
+
+        let model = AnthropicMessagesLanguageModel(
+            modelId: .init(rawValue: "claude-sonnet-4-5-20250929"),
+            config: makeProviderOptionsTestConfig(fetch: fetch)
+        )
+
+        _ = try await model.doGenerate(options: .init(
+            prompt: providerOptionsTestPrompt,
+            providerOptions: [
+                "anthropic": [
+                    "thinking": .object([
+                        "type": .string("enabled"),
+                        "budgetTokens": .number(2048),
+                        "display": .string("omitted"),
+                    ])
+                ]
+            ]
+        ))
+
+        let json = decodeRequestJSON(await capture.current())
+        if let thinking = json?["thinking"] as? [String: Any] {
+            #expect(thinking["type"] as? String == "enabled")
+            #expect(thinking["budget_tokens"] as? Double == 2048)
+            #expect(thinking["display"] as? String == "omitted")
+        } else {
+            Issue.record("Expected thinking payload")
+        }
+    }
+
+    @Test("omits thinking.display when not set")
+    func omitsDisplayWhenNotSet() async throws {
+        let capture = RequestCapture()
+        let responseData = try makeProviderOptionsTestResponseData(model: "claude-sonnet-4-5-20250929")
+
+        let fetch: FetchFunction = { request in
+            await capture.store(request)
+            return FetchResponse(body: .data(responseData), urlResponse: makeProviderOptionsTestHTTPResponse())
+        }
+
+        let model = AnthropicMessagesLanguageModel(
+            modelId: .init(rawValue: "claude-sonnet-4-5-20250929"),
+            config: makeProviderOptionsTestConfig(fetch: fetch)
+        )
+
+        _ = try await model.doGenerate(options: .init(
+            prompt: providerOptionsTestPrompt,
+            providerOptions: [
+                "anthropic": [
+                    "thinking": .object([
+                        "type": .string("adaptive")
+                    ])
+                ]
+            ]
+        ))
+
+        let json = decodeRequestJSON(await capture.current())
+        if let thinking = json?["thinking"] as? [String: Any] {
+            #expect(thinking["type"] as? String == "adaptive")
+            #expect(thinking["display"] == nil)
+        } else {
+            Issue.record("Expected thinking payload")
+        }
+    }
+
     @Test("sends speed=fast and fast-mode beta header")
     func sendsSpeedFast() async throws {
         let capture = RequestCapture()

--- a/Tests/AnthropicProviderTests/AnthropicMessagesLanguageModelProviderOptionsRequestTests.swift
+++ b/Tests/AnthropicProviderTests/AnthropicMessagesLanguageModelProviderOptionsRequestTests.swift
@@ -157,7 +157,7 @@ struct AnthropicMessagesLanguageModelProviderOptionsRequestTests {
             Issue.record("Expected output_config payload")
         }
 
-        #expect(anthropicBetaSet(await capture.current()) == Set(["effort-2025-11-24"]))
+        #expect(anthropicBetaSet(await capture.current()) == nil)
     }
 
     @Test("reads provider options from custom provider key")
@@ -194,7 +194,7 @@ struct AnthropicMessagesLanguageModelProviderOptionsRequestTests {
             Issue.record("Expected output_config payload")
         }
 
-        #expect(anthropicBetaSet(await capture.current()) == Set(["effort-2025-11-24"]))
+        #expect(anthropicBetaSet(await capture.current()) == nil)
     }
 
     @Test("custom provider key: passes disableParallelToolUse via tool_choice")
@@ -532,7 +532,7 @@ struct AnthropicMessagesLanguageModelProviderOptionsRequestTests {
             Issue.record("Expected output_config payload")
         }
 
-        #expect(anthropicBetaSet(await capture.current()) == Set(["effort-2025-11-24"]))
+        #expect(anthropicBetaSet(await capture.current()) == nil)
     }
 
     @Test("sends compact_20260112 with trigger")


### PR DESCRIPTION
## Description

Anthropic's Opus 4.7 introduces a new xhigh effort level between high and max for finer control over reasoning depth vs latency.

Also removes the effort-2025-11-24 beta flag since effort is now GA and is actually causing errors when using it with 4.7.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

N/A

## Testing

- [x] All tests pass (`swift test`)
- [ ] Added tests for new functionality
- [ ] Verified upstream parity (if applicable)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [x] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [x] Updated CHANGELOG.md (if applicable)
