### PR TITLE
Round-trip assistant reasoning as reasoning_content (openai-compatible)

### DIFF
--- a/Sources/OpenAICompatibleProvider/Chat/ConvertToOpenAICompatibleChatMessages.swift
+++ b/Sources/OpenAICompatibleProvider/Chat/ConvertToOpenAICompatibleChatMessages.swift
@@ -104,12 +104,26 @@ public func convertToOpenAICompatibleChatMessages(
             ]
 
             var textAccumulator = ""
+            // Reasoning parts in assistant messages are accumulated and
+            // sent as a top-level `reasoning_content` field on the
+            // outgoing assistant message. This matches the upstream
+            // `@ai-sdk/openai-compatible` behavior and lets reasoning
+            // models (DeepSeek, Kimi, Qwen3, GLM, etc.) round-trip
+            // their prior turn's reasoning back to the provider for
+            // continuity. Per-provider field naming overrides (e.g.
+            // OpenRouter's `reasoning_details`) can still be applied
+            // by callers via the `openaiCompatible` providerOptions
+            // namespace, which `metadata(from:)` merges into the final
+            // payload below.
+            var reasoningAccumulator = ""
             var toolCalls: [[String: JSONValue]] = []
 
             for content in contents {
                 switch content {
                 case .text(let textPart):
                     textAccumulator.append(textPart.text)
+                case .reasoning(let reasoningPart):
+                    reasoningAccumulator.append(reasoningPart.text)
                 case .toolCall(let call):
                     let inputData = try JSONEncoder().encode(call.input)
                     let arguments = String(data: inputData, encoding: .utf8) ?? "{}"
@@ -125,8 +139,6 @@ public func convertToOpenAICompatibleChatMessages(
                         payload[key] = value
                     }
                     toolCalls.append(payload)
-                case .reasoning:
-                    throw UnsupportedFunctionalityError(functionality: "reasoning content in assistant message")
                 case .file:
                     throw UnsupportedFunctionalityError(functionality: "file content in assistant message")
                 case .toolResult:
@@ -135,6 +147,9 @@ public func convertToOpenAICompatibleChatMessages(
             }
 
             builder["content"] = .string(textAccumulator)
+            if !reasoningAccumulator.isEmpty {
+                builder["reasoning_content"] = .string(reasoningAccumulator)
+            }
             if !toolCalls.isEmpty {
                 builder["tool_calls"] = .array(toolCalls.map(JSONValue.object))
             }

--- a/Tests/OpenAICompatibleProviderTests/OpenAICompatibleChatMessagesConverterTests.swift
+++ b/Tests/OpenAICompatibleProviderTests/OpenAICompatibleChatMessagesConverterTests.swift
@@ -706,6 +706,120 @@ struct OpenAICompatibleChatMessagesConverterTests {
         #expect(result == expected)
     }
 
+    @Test("accumulates assistant reasoning into reasoning_content")
+    func accumulatesReasoningIntoReasoningContent() throws {
+        let prompt: LanguageModelV3Prompt = [
+            .assistant(
+                content: [
+                    .reasoning(LanguageModelV3ReasoningPart(text: "Let me think. ")),
+                    .reasoning(LanguageModelV3ReasoningPart(text: "First step.")),
+                    .text(LanguageModelV3TextPart(text: "Hello there"))
+                ],
+                providerOptions: nil
+            )
+        ]
+
+        let result = try convertToOpenAICompatibleChatMessages(prompt: prompt)
+        let expected: [JSONValue] = [
+            .object([
+                "role": .string("assistant"),
+                "content": .string("Hello there"),
+                "reasoning_content": .string("Let me think. First step.")
+            ])
+        ]
+        #expect(result == expected)
+    }
+
+    @Test("preserves reasoning_content when assistant message contains tool calls")
+    func reasoningRoundTripsWithToolCalls() throws {
+        let prompt: LanguageModelV3Prompt = [
+            .assistant(
+                content: [
+                    .reasoning(LanguageModelV3ReasoningPart(text: "I need to read the README first.")),
+                    .text(LanguageModelV3TextPart(text: "I'll explore the repo.")),
+                    .toolCall(LanguageModelV3ToolCallPart(
+                        toolCallId: "call_1",
+                        toolName: "ReadFile",
+                        input: .object(["file": .string("README.md")])
+                    ))
+                ],
+                providerOptions: nil
+            )
+        ]
+
+        let result = try convertToOpenAICompatibleChatMessages(prompt: prompt)
+        let expected: [JSONValue] = [
+            .object([
+                "role": .string("assistant"),
+                "content": .string("I'll explore the repo."),
+                "reasoning_content": .string("I need to read the README first."),
+                "tool_calls": .array([
+                    .object([
+                        "type": .string("function"),
+                        "id": .string("call_1"),
+                        "function": .object([
+                            "name": .string("ReadFile"),
+                            "arguments": .string("{\"file\":\"README.md\"}")
+                        ])
+                    ])
+                ])
+            ])
+        ]
+        #expect(result == expected)
+    }
+
+    @Test("omits reasoning_content when no reasoning parts are present")
+    func omitsReasoningContentWhenAbsent() throws {
+        let prompt: LanguageModelV3Prompt = [
+            .assistant(
+                content: [
+                    .text(LanguageModelV3TextPart(text: "Just text"))
+                ],
+                providerOptions: nil
+            )
+        ]
+
+        let result = try convertToOpenAICompatibleChatMessages(prompt: prompt)
+        let expected: [JSONValue] = [
+            .object([
+                "role": .string("assistant"),
+                "content": .string("Just text")
+            ])
+        ]
+        #expect(result == expected)
+    }
+
+    @Test("metadata-supplied reasoning_content overrides accumulated reasoning")
+    func metadataOverridesAccumulatedReasoning() throws {
+        // Callers (e.g. opencode-style transforms) may pre-strip
+        // reasoning parts and inject `reasoning_content` directly via
+        // providerOptions. When both paths are used, the metadata
+        // value wins because it's merged after the accumulator.
+        let prompt: LanguageModelV3Prompt = [
+            .assistant(
+                content: [
+                    .reasoning(LanguageModelV3ReasoningPart(text: "raw thought")),
+                    .text(LanguageModelV3TextPart(text: "Answer"))
+                ],
+                providerOptions: [
+                    "openaiCompatible": [
+                        "reasoning_content": .string("metadata thought")
+                    ]
+                ]
+            )
+        ]
+
+        let result = try convertToOpenAICompatibleChatMessages(prompt: prompt)
+        let expected: [JSONValue] = [
+            .object([
+                "role": .string("assistant"),
+                "content": .string("Answer"),
+                "reasoning_content": .string("metadata thought")
+            ])
+        ]
+        #expect(result == expected)
+    }
+
     @Test("handles metadata collisions and overwrites in tool calls")
     func handlesMetadataCollisionsInToolCalls() throws {
         let prompt: LanguageModelV3Prompt = [


### PR DESCRIPTION
## Description

The Swift port of `convertToOpenAICompatibleChatMessages` throws `UnsupportedFunctionalityError("reasoning content in assistant message")` whenever an assistant message contains `.reasoning` parts. The upstream TypeScript implementation accumulates these parts and emits them as a top-level `reasoning_content` field on the outgoing assistant payload instead.

This divergence breaks any multi-step tool flow against providers that stream reasoning via `reasoning_content` (Kimi K2.6, DeepSeek, Qwen3, GLM, xAI Grok, etc.). During `streamText`'s internal multi-step loop, the SDK builds the next request from the assistant message it just generated via `toResponseMessages`, which preserves `.reasoning` parts. On step 2 the converter throws and the entire agent loop errors out immediately after the first tool call completes.

This PR ports the upstream accumulator behavior:

- Adds a `reasoningAccumulator` to the assistant case alongside the existing text and tool-call accumulators.
- Appends `.reasoning(part).text` to the accumulator instead of throwing.
- When the accumulator is non-empty, emits `reasoning_content: <accumulated>` on the outgoing message.

Per-provider field naming overrides (e.g. OpenRouter's `reasoning_details`) can still be applied by callers via the `openaiCompatible` providerOptions namespace, which `metadata(from:)` merges into the final payload after the accumulator — so metadata-supplied `reasoning_content` wins over the accumulator when both are present.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

- Upstream file(s): [`packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts` (lines 157–218)](https://github.com/vercel/ai/blob/main/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts#L157-L218)
- Upstream commit: The upstream has always accumulated reasoning — the Swift port introduced the divergence by translating the `case 'reasoning'` branch as a `throw` instead of an accumulator.

## Testing

- [x] All tests pass (`swift test`)
- [x] Added tests for new functionality
- [x] Verified upstream parity (if applicable)

Four new converter tests added to `OpenAICompatibleChatMessagesConverterTests.swift`:

| Test | What it verifies |
|------|-----------------|
| `accumulatesReasoningIntoReasoningContent` | Multiple `.reasoning` parts are concatenated into a single `reasoning_content` string |
| `reasoningRoundTripsWithToolCalls` | `reasoning_content` coexists with `content` and `tool_calls` on the same assistant message |
| `omitsReasoningContentWhenAbsent` | No `reasoning_content` key when the assistant message has no reasoning parts |
| `metadataOverridesAccumulatedReasoning` | `providerOptions.openaiCompatible.reasoning_content` wins over the accumulator (metadata precedence) |

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [x] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)

## Additional Notes

The `OpenAICompatibleAssistantMessage` type in `openai-compatible-api-types.ts` already declares `reasoning_content?: string` on line 59, confirming the upstream intent for this field to be present on assistant messages. The Swift wire types don't need updating since the converter emits raw `JSONValue` payloads.
