### PR TITLE
Remove GA fine-grained-tool-streaming beta, translate to per-tool eag…

### DIFF
--- a/Sources/AnthropicProvider/AnthropicMessagesLanguageModel.swift
+++ b/Sources/AnthropicProvider/AnthropicMessagesLanguageModel.swift
@@ -52,7 +52,6 @@ private struct AnthropicRequestArguments {
     let betas: Set<String>
     let usesJsonResponseTool: Bool
     let toolNameMapping: AnthropicToolNameMapping
-    let toolStreaming: Bool
     let providerOptionsName: String
     let usedCustomProviderKey: Bool
 }
@@ -149,12 +148,9 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
     public func doStream(options: LanguageModelV3CallOptions) async throws
         -> LanguageModelV3StreamResult
     {
-        let prepared = try await prepareRequest(options: options)
+        let prepared = try await prepareRequest(options: options, stream: true)
 
-        var betas = prepared.betas
-        if prepared.toolStreaming {
-            betas.insert("fine-grained-tool-streaming-2025-05-14")
-        }
+        let betas = prepared.betas
 
         var requestBody = prepared.body
         requestBody["stream"] = .bool(true)
@@ -503,7 +499,7 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
         return merged
     }
 
-    private func prepareRequest(options: LanguageModelV3CallOptions) async throws
+    private func prepareRequest(options: LanguageModelV3CallOptions, stream: Bool = false) async throws
         -> AnthropicRequestArguments
     {
         var warnings: [SharedV3Warning] = []
@@ -594,7 +590,7 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
 
         let usesJsonResponseTool = jsonResponseTool != nil
         let contextManagement = anthropicOptions?.contextManagement
-        let toolStreaming = anthropicOptions?.toolStreaming ?? true
+        let defaultEagerInputStreaming = stream && (anthropicOptions?.toolStreaming ?? true)
         let cacheControlValidator = CacheControlValidator()
 
         let toolNameMapping = AnthropicToolNameMapping.create(
@@ -953,7 +949,8 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
             toolChoice: jsonResponseTool != nil ? .required : options.toolChoice,
             disableParallelToolUse: jsonResponseTool != nil ? true : anthropicOptions?.disableParallelToolUse,
             supportsStructuredOutput: jsonResponseTool == nil ? supportsStructuredOutput : false,
-            cacheControlValidator: cacheControlValidator
+            cacheControlValidator: cacheControlValidator,
+            defaultEagerInputStreaming: defaultEagerInputStreaming
         )
 
         warnings.append(contentsOf: preparedTools.warnings)
@@ -984,7 +981,6 @@ public final class AnthropicMessagesLanguageModel: LanguageModelV3 {
             betas: betas,
             usesJsonResponseTool: usesJsonResponseTool,
             toolNameMapping: toolNameMapping,
-            toolStreaming: toolStreaming,
             providerOptionsName: providerOptionsName,
             usedCustomProviderKey: usedCustomProviderKey
         )

--- a/Sources/AnthropicProvider/AnthropicPrepareTools.swift
+++ b/Sources/AnthropicProvider/AnthropicPrepareTools.swift
@@ -56,7 +56,8 @@ public func prepareAnthropicTools(
     toolChoice: LanguageModelV3ToolChoice?,
     disableParallelToolUse: Bool?,
     supportsStructuredOutput: Bool = false,
-    cacheControlValidator: CacheControlValidator? = nil
+    cacheControlValidator: CacheControlValidator? = nil,
+    defaultEagerInputStreaming: Bool = false
 ) async throws -> AnthropicPreparedTools {
     guard let tools, !tools.isEmpty else {
         return AnthropicPreparedTools(tools: nil, toolChoice: nil, warnings: [], betas: [])
@@ -109,6 +110,20 @@ public func prepareAnthropicTools(
                         betas.insert("advanced-tool-use-2025-11-20")
                     }
                 }
+            }
+
+            // eager_input_streaming is only supported on custom (function) tools.
+            // Fall back to the model-level default when the tool doesn't set it.
+            let eagerInputStreaming: Bool? = {
+                if let anthropicOptions = functionTool.providerOptions?["anthropic"],
+                   let value = anthropicOptions["eagerInputStreaming"],
+                   case .bool(let flag) = value {
+                    return flag
+                }
+                return defaultEagerInputStreaming ? true : nil
+            }()
+            if let eagerInputStreaming {
+                payload["eager_input_streaming"] = .bool(eagerInputStreaming)
             }
 
             if let inputExamples = functionTool.inputExamples {

--- a/Tests/AnthropicProviderTests/AnthropicMessagesFixtureTests.swift
+++ b/Tests/AnthropicProviderTests/AnthropicMessagesFixtureTests.swift
@@ -269,7 +269,6 @@ struct AnthropicMessagesFixtureTests {
 
         let request = await capture.current()
         #expect(anthropicBetaSet(request) == Set([
-            "fine-grained-tool-streaming-2025-05-14",
             "mcp-client-2025-04-04"
         ]))
 
@@ -444,8 +443,7 @@ struct AnthropicMessagesFixtureTests {
 
         let request = await capture.current()
         #expect(anthropicBetaSet(request) == Set([
-            "code-execution-web-tools-2026-02-09",
-            "fine-grained-tool-streaming-2025-05-14"
+            "code-execution-web-tools-2026-02-09"
         ]))
 
         let toolCalls = parts.compactMap { part -> LanguageModelV3ToolCall? in

--- a/Tests/AnthropicProviderTests/AnthropicMessagesLanguageModelProviderOptionsRequestTests.swift
+++ b/Tests/AnthropicProviderTests/AnthropicMessagesLanguageModelProviderOptionsRequestTests.swift
@@ -1303,4 +1303,118 @@ struct AnthropicMessagesLanguageModelProviderOptionsRequestTests {
         let betas = anthropicBetaSet(await capture.current())
         #expect(betas == Set(["extended-cache-ttl-2025-04-11"]))
     }
+
+    // MARK: - eager_input_streaming (GA replacement for fine-grained-tool-streaming beta)
+
+    @Test("defaults to per-tool eager_input_streaming on streaming requests")
+    func defaultsEagerInputStreamingOnStream() async throws {
+        let capture = RequestCapture()
+
+        let ssePayloads = [
+            #"{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1},"content":[]}}"#,
+            #"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#,
+            #"{"type":"message_stop"}"#,
+        ]
+        let sseBody = ssePayloads.map { "event: message\ndata: \($0)\n\n" }.joined()
+        let sseData = Data(sseBody.utf8)
+
+        let fetch: FetchFunction = { request in
+            await capture.store(request)
+            return FetchResponse(body: .data(sseData), urlResponse: makeProviderOptionsTestHTTPResponse())
+        }
+
+        let model = AnthropicMessagesLanguageModel(
+            modelId: .init(rawValue: "claude-3-haiku-20240307"),
+            config: makeProviderOptionsTestConfig(fetch: fetch)
+        )
+
+        let result = try await model.doStream(options: .init(
+            prompt: providerOptionsTestPrompt,
+            tools: [
+                .function(.init(
+                    name: "get_weather",
+                    inputSchema: .object([:]),
+                    description: "Get weather"
+                ))
+            ]
+        ))
+        for try await _ in result.stream {}
+
+        let json = decodeRequestJSON(await capture.current())
+        let tools = json?["tools"] as? [[String: Any]]
+        #expect(tools?.first?["eager_input_streaming"] as? Bool == true)
+        // No legacy beta header
+        #expect(anthropicBetaSet(await capture.current()) == nil)
+    }
+
+    @Test("does not add eager_input_streaming when toolStreaming is false")
+    func noEagerInputStreamingWhenOptOut() async throws {
+        let capture = RequestCapture()
+
+        let ssePayloads = [
+            #"{"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1},"content":[]}}"#,
+            #"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#,
+            #"{"type":"message_stop"}"#,
+        ]
+        let sseBody = ssePayloads.map { "event: message\ndata: \($0)\n\n" }.joined()
+        let sseData = Data(sseBody.utf8)
+
+        let fetch: FetchFunction = { request in
+            await capture.store(request)
+            return FetchResponse(body: .data(sseData), urlResponse: makeProviderOptionsTestHTTPResponse())
+        }
+
+        let model = AnthropicMessagesLanguageModel(
+            modelId: .init(rawValue: "claude-3-haiku-20240307"),
+            config: makeProviderOptionsTestConfig(fetch: fetch)
+        )
+
+        let result = try await model.doStream(options: .init(
+            prompt: providerOptionsTestPrompt,
+            tools: [
+                .function(.init(
+                    name: "get_weather",
+                    inputSchema: .object([:]),
+                    description: "Get weather"
+                ))
+            ],
+            providerOptions: ["anthropic": ["toolStreaming": .bool(false)]]
+        ))
+        for try await _ in result.stream {}
+
+        let json = decodeRequestJSON(await capture.current())
+        let tools = json?["tools"] as? [[String: Any]]
+        #expect(tools?.first?["eager_input_streaming"] == nil)
+    }
+
+    @Test("does not default eager_input_streaming on non-streaming (generate) calls")
+    func noEagerInputStreamingOnGenerate() async throws {
+        let capture = RequestCapture()
+        let responseData = try makeProviderOptionsTestResponseData(model: "claude-3-haiku-20240307")
+
+        let fetch: FetchFunction = { request in
+            await capture.store(request)
+            return FetchResponse(body: .data(responseData), urlResponse: makeProviderOptionsTestHTTPResponse())
+        }
+
+        let model = AnthropicMessagesLanguageModel(
+            modelId: .init(rawValue: "claude-3-haiku-20240307"),
+            config: makeProviderOptionsTestConfig(fetch: fetch)
+        )
+
+        _ = try await model.doGenerate(options: .init(
+            prompt: providerOptionsTestPrompt,
+            tools: [
+                .function(.init(
+                    name: "get_weather",
+                    inputSchema: .object([:]),
+                    description: "Get weather"
+                ))
+            ]
+        ))
+
+        let json = decodeRequestJSON(await capture.current())
+        let tools = json?["tools"] as? [[String: Any]]
+        #expect(tools?.first?["eager_input_streaming"] == nil)
+    }
 }


### PR DESCRIPTION
## Description

Ports the upstream PR [#14542](https://github.com/vercel/ai/pull/14542) which was merged to address Bedrock's passthrough validation rejecting the legacy beta header on `claude-opus-4-7`. The `toolStreaming` option on `AnthropicProviderOptions` is preserved and now drives per-tool `eager_input_streaming` instead of the beta header, maintaining the same default-on streaming behavior.

Per the [Anthropic migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide), fine-grained tool streaming is now GA on all Anthropic models and platforms.

**Changes:**
- Removed the `fine-grained-tool-streaming-2025-05-14` beta header injection in `doStream()`
- Added `defaultEagerInputStreaming` parameter to `prepareAnthropicTools()`, computed as `stream && (toolStreaming ?? true)`
- Function tools now receive `eager_input_streaming: true` by default on streaming requests; per-tool `providerOptions.anthropic.eagerInputStreaming` takes precedence
- `toolStreaming: false` opts out — no default is injected
- Non-streaming (`doGenerate`) calls never apply `eager_input_streaming`
- Added 3 new tests: default-on for streaming, opt-out via `toolStreaming: false`, no-op on generate
- Updated fixture test expectations (MCP, web-fetch-tool)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Upstream parity (porting from Vercel AI SDK)

## Upstream Reference

- Upstream file(s): `packages/anthropic/src/anthropic-messages-language-model.ts`, `packages/anthropic/src/anthropic-prepare-tools.ts`, `packages/anthropic/src/anthropic-messages-options.ts`
- Upstream commit: https://github.com/vercel/ai/pull/14542

## Testing

- [x] All tests pass (`swift test`) — 3747 tests
- [x] Added tests for new functionality (3 new tests)
- [x] Verified upstream parity (if applicable)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Added/updated documentation as needed
- [ ] Added upstream reference in file headers (if applicable)
- [x] No breaking changes (or documented in CHANGELOG)
- [ ] Updated CHANGELOG.md (if applicable)