### PR TITLE
fix: track skills v4 provider contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ parity/
 git-local-config.md
 .claude/
 .codex/
-skills/
+/skills/
 !.agents/
 !.agents/skills/
 !.agents/skills/**

--- a/Sources/AISDKProvider/Skills/V4/SkillsV4.swift
+++ b/Sources/AISDKProvider/Skills/V4/SkillsV4.swift
@@ -1,0 +1,22 @@
+/**
+ Skills specification version 4.
+
+ Port of `@ai-sdk/provider/src/skills/v4/skills-v4.ts`.
+ */
+public protocol SkillsV4: Sendable {
+    /// Skills interface version discriminator.
+    var specificationVersion: String { get }
+
+    /// Provider identifier.
+    var provider: String { get }
+
+    /// Uploads a new skill from the given files.
+    func uploadSkill(options: SkillsV4UploadSkillCallOptions) async throws -> SkillsV4UploadSkillResult
+}
+
+/**
+ Provider capability marker for providers that expose a v4 skills interface.
+ */
+public protocol SkillsProvider: Sendable {
+    func skills() -> any SkillsV4
+}

--- a/Sources/AISDKProvider/Skills/V4/SkillsV4UploadSkillCallOptions.swift
+++ b/Sources/AISDKProvider/Skills/V4/SkillsV4UploadSkillCallOptions.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/**
+ File payload for a v4 skill upload.
+
+ Port of `SkillsV4File` from `@ai-sdk/provider/src/skills/v4/skills-v4-upload-skill-call-options.ts`.
+ */
+public struct SkillsV4File: Sendable, Equatable {
+    public let path: String
+    public let data: SharedV4DataContent
+
+    public var content: SharedV4DataContent {
+        data
+    }
+
+    public init(path: String, data: SharedV4DataContent) {
+        self.path = path
+        self.data = data
+    }
+
+    public init(path: String, content: SharedV4DataContent) {
+        self.path = path
+        self.data = content
+    }
+}
+
+/**
+ Options for uploading a skill via the skills interface.
+
+ Port of `@ai-sdk/provider/src/skills/v4/skills-v4-upload-skill-call-options.ts`.
+ */
+public struct SkillsV4UploadSkillCallOptions: Sendable, Equatable {
+    public let files: [SkillsV4File]
+    public let displayTitle: String?
+    public let providerOptions: SharedV4ProviderOptions?
+
+    public init(
+        files: [SkillsV4File],
+        displayTitle: String? = nil,
+        providerOptions: SharedV4ProviderOptions? = nil
+    ) {
+        self.files = files
+        self.displayTitle = displayTitle
+        self.providerOptions = providerOptions
+    }
+}

--- a/Sources/AISDKProvider/Skills/V4/SkillsV4UploadSkillResult.swift
+++ b/Sources/AISDKProvider/Skills/V4/SkillsV4UploadSkillResult.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/**
+ Result of uploading a skill via the skills interface.
+
+ Port of `@ai-sdk/provider/src/skills/v4/skills-v4-upload-skill-result.ts`.
+ */
+public struct SkillsV4UploadSkillResult: Sendable, Equatable {
+    public let providerReference: SharedV4ProviderReference
+    public let displayTitle: String?
+    public let name: String?
+    public let description: String?
+    public let latestVersion: String?
+    public let providerMetadata: SharedV4ProviderMetadata?
+    public let warnings: [SharedV4Warning]
+
+    public init(
+        providerReference: SharedV4ProviderReference,
+        displayTitle: String? = nil,
+        name: String? = nil,
+        description: String? = nil,
+        latestVersion: String? = nil,
+        providerMetadata: SharedV4ProviderMetadata? = nil,
+        warnings: [SharedV4Warning] = []
+    ) {
+        self.providerReference = providerReference
+        self.displayTitle = displayTitle
+        self.name = name
+        self.description = description
+        self.latestVersion = latestVersion
+        self.providerMetadata = providerMetadata
+        self.warnings = warnings
+    }
+}


### PR DESCRIPTION
## Summary
- track missing AISDKProvider Skills V4 contracts used by ProviderV4
- scope the root skills ignore rule so nested Swift Sources/Skills files are not ignored

## Validation
- swift build
- AGENT=1 swift test