### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-02
+
+Upstream parity refresh against Vercel AI SDK commit `85a80fc6e71558717899e30c9f1fc0e9eb7d733d`.
+
+### Added
+- Core: add the V4 provider contract foundation across language, embedding, image, speech, transcription, video, reranking, realtime, middleware, files, skills, warnings, provider references, and shared file-data types.
+- Core: route high-level text, object, embedding, rerank, image, speech, transcription, and video flows through V4-compatible adapters while preserving existing V2/V3 provider compatibility.
+- Core: add AI-level `uploadFile` and `uploadSkill` helpers with provider capability checks, media-type detection, multipart support, and direct regression coverage.
+- Provider utils: add V4 parity helpers for provider references, reasoning mapping, header normalization, same-origin and filename handling, nullable filtering, line extraction, media-type detection, inline file-data conversion, multipart form data, validated downloads, size-limited reads, model option serialization, streaming tool-call tracking, tool-name mapping, standard-schema normalization, response cancellation, delayed promises, and browser runtime detection.
+- OpenAI Compatible: add V4 provider-surface adapters and regression coverage for the OpenAI-compatible chat path.
+- Anthropic: add `files()` and `skills()` upload surfaces with multipart request support, beta headers, uploaded-skill version metadata, and provider metadata mapping.
+
+### Fixed
+- Amazon Bedrock: preserve assistant reasoning during prompt conversion even when Bedrock metadata is absent, and keep reasoning text intact when signatures are present.
+- Anthropic: align upload file-data handling with V4 file data contracts.
+- OpenAI Compatible: preserve `reasoning_content` round-trips for assistant reasoning.
+- Tool execution: cancel in-flight tool tasks when streaming is stopped.
+- MCP HTTP transport: stabilize inbound SSE reopen behavior.
+- CI/release: track the V4 skills contract files in Git so protected GitHub checkouts build cleanly.
+
+### Docs
+- README and Starlight docs now reference `0.18.0`.
+- Provider counts now reflect the current 38 concrete provider modules.
+- Public examples and docs snippets now compile against the current V4 registry, streaming, provider-warning, and OpenAI Responses helper APIs.
+- Upstream parity evidence now records the refreshed V4 core/provider-utils foundation and remaining provider-migration gaps.
+
 ## [0.17.6] - 2026-03-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fteunlao%2Fswift-ai-sdk%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/teunlao/swift-ai-sdk)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fteunlao%2Fswift-ai-sdk%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/teunlao/swift-ai-sdk)
 
-A unified AI SDK for Swift: streaming chat/completions, structured outputs, tool/function/MCP calling, and middleware — with 37 provider modules via one API (OpenAI, Anthropic, Google, Groq, xAI, Vercel, TogetherAI, and more). Based on the [Vercel AI SDK](https://github.com/vercel/ai) with a focus on full API parity.
+A unified AI SDK for Swift: streaming chat/completions, structured outputs, tool/function/MCP calling, and middleware — with 38 provider modules via one API (OpenAI, Anthropic, Google, Groq, xAI, Vercel, TogetherAI, and more). Based on the [Vercel AI SDK](https://github.com/vercel/ai) with a focus on full API parity.
 
 **[Documentation](https://swift-ai-sdk-docs.vercel.app)** | **[Getting Started](https://swift-ai-sdk-docs.vercel.app/getting-started/ios-macos-quickstart)** | **[Examples](examples/)** | **[Discussions](https://github.com/teunlao/swift-ai-sdk/discussions)**
 
@@ -36,8 +36,8 @@ Add the package to your `Package.swift`:
 ```swift
 // Package.swift
 dependencies: [
-  // Use the latest release tag (e.g. "0.17.6").
-  .package(url: "https://github.com/teunlao/swift-ai-sdk.git", from: "0.17.6")
+  // Use the latest release tag (e.g. "0.18.0").
+  .package(url: "https://github.com/teunlao/swift-ai-sdk.git", from: "0.18.0")
 ],
 targets: [
   .target(
@@ -122,7 +122,7 @@ let summary = try await generateObject(
   model: openai("gpt-5"),
   schema: Release.self,
   schemaName: "release_summary",
-  prompt: "Summarize Swift AI SDK 0.17.6: streaming + tools."
+  prompt: "Summarize Swift AI SDK 0.18.0: streaming + tools."
 ).object
 
 print("Release: \\(summary.name) (\\(summary.version))")

--- a/Sources/AISDKProviderUtils/Versioning/SDKReleaseVersion.swift
+++ b/Sources/AISDKProviderUtils/Versioning/SDKReleaseVersion.swift
@@ -3,5 +3,5 @@ import Foundation
 /// Shared release version used across all providers.
 public enum SDKReleaseVersion {
     /// Returns the release version string.
-    public static let value: String = "0.17.6"
+    public static let value: String = "0.18.0"
 }

--- a/apps/docs/src/content/docs/ai-sdk-core/provider-management.mdx
+++ b/apps/docs/src/content/docs/ai-sdk-core/provider-management.mdx
@@ -162,9 +162,9 @@ The provider id will become the prefix of the model id: `providerId:modelId`.
 import SwiftAISDK
 
 let result = try await generateText(
-  model: registry.languageModel(id: "openai:gpt-4o"), // default separator
+  model: .v4(registry.languageModel(id: "openai:gpt-4o")), // default separator
   // or with custom separator:
-  // model: customSeparatorRegistry.languageModel(id: "openai > gpt-4o"),
+  // model: .v4(customSeparatorRegistry.languageModel(id: "openai > gpt-4o")),
   prompt: "Invent a new holiday and describe its traditions."
 )
 ```
@@ -261,7 +261,7 @@ let registry = createProviderRegistry(
 )
 
 // Usage:
-let model = registry.languageModel(id: "anthropic > reasoning")
+let model = try registry.languageModel(id: "anthropic > reasoning")
 ```
 
 ## Registry with Middleware
@@ -287,7 +287,7 @@ let registry = createProviderRegistry(
 
 // All language models from this registry will have reasoning extraction enabled
 let result = try await generateText(
-  model: registry.languageModel(id: "openai:gpt-4o"),
+  model: .v4(registry.languageModel(id: "openai:gpt-4o")),
   prompt: "Think step by step and wrap reasoning in <think> tags"
 )
 ```

--- a/apps/docs/src/content/docs/ai-sdk-core/testing.mdx
+++ b/apps/docs/src/content/docs/ai-sdk-core/testing.mdx
@@ -31,10 +31,10 @@ let result = try await generateText(
     doGenerate: .function { _ in
       LanguageModelV3GenerateResult(
         content: [.text(LanguageModelV3Text(text: "Hello, world!"))],
-        finishReason: .stop,
+        finishReason: LanguageModelV3FinishReason(unified: .stop),
         usage: LanguageModelV3Usage(
-          inputTokens: 10,
-          outputTokens: 20
+          inputTokens: .init(total: 10),
+          outputTokens: .init(total: 20)
         )
       )
     }
@@ -63,10 +63,10 @@ let result = try await streamText(
             .textDelta(id: "text-1", delta: "world!", providerMetadata: nil),
             .textEnd(id: "text-1", providerMetadata: nil),
             .finish(
-              finishReason: .stop,
+              finishReason: LanguageModelV3FinishReason(unified: .stop),
               usage: LanguageModelV3Usage(
-                inputTokens: 3,
-                outputTokens: 10
+                inputTokens: .init(total: 3),
+                outputTokens: .init(total: 10)
               ),
               providerMetadata: nil
             )
@@ -96,8 +96,8 @@ let mockModel = MockLanguageModelV3(
   doGenerate: .function { _ in
     LanguageModelV3GenerateResult(
       content: [.text(LanguageModelV3Text(text: "Response"))],
-      finishReason: .stop,
-      usage: LanguageModelV3Usage(inputTokens: 5, outputTokens: 5)
+      finishReason: LanguageModelV3FinishReason(unified: .stop),
+      usage: LanguageModelV3Usage(inputTokens: .init(total: 5), outputTokens: .init(total: 5))
     )
   }
 )
@@ -123,8 +123,8 @@ let stopModel = MockLanguageModelV3(
   doGenerate: .function { _ in
     LanguageModelV3GenerateResult(
       content: [.text(LanguageModelV3Text(text: "Complete"))],
-      finishReason: .stop,
-      usage: LanguageModelV3Usage(inputTokens: 3, outputTokens: 2)
+      finishReason: LanguageModelV3FinishReason(unified: .stop),
+      usage: LanguageModelV3Usage(inputTokens: .init(total: 3), outputTokens: .init(total: 2))
     )
   }
 )
@@ -134,8 +134,8 @@ let lengthModel = MockLanguageModelV3(
   doGenerate: .function { _ in
     LanguageModelV3GenerateResult(
       content: [.text(LanguageModelV3Text(text: "Truncated..."))],
-      finishReason: .length,
-      usage: LanguageModelV3Usage(inputTokens: 3, outputTokens: 100)
+      finishReason: LanguageModelV3FinishReason(unified: .length),
+      usage: LanguageModelV3Usage(inputTokens: .init(total: 3), outputTokens: .init(total: 100))
     )
   }
 )
@@ -159,13 +159,13 @@ import AISDKProvider
 let mockResponses = mockValues(
   LanguageModelV3GenerateResult(
     content: [.text(LanguageModelV3Text(text: "First response"))],
-    finishReason: .stop,
-    usage: LanguageModelV3Usage(inputTokens: 10, outputTokens: 5)
+    finishReason: LanguageModelV3FinishReason(unified: .stop),
+    usage: LanguageModelV3Usage(inputTokens: .init(total: 10), outputTokens: .init(total: 5))
   ),
   LanguageModelV3GenerateResult(
     content: [.text(LanguageModelV3Text(text: "Second response"))],
-    finishReason: .stop,
-    usage: LanguageModelV3Usage(inputTokens: 10, outputTokens: 5)
+    finishReason: LanguageModelV3FinishReason(unified: .stop),
+    usage: LanguageModelV3Usage(inputTokens: .init(total: 10), outputTokens: .init(total: 5))
   )
 )
 
@@ -205,8 +205,8 @@ let result = try await streamText(
             .textDelta(id: "text-1", delta: " stream", providerMetadata: nil),
             .textEnd(id: "text-1", providerMetadata: nil),
             .finish(
-              finishReason: .stop,
-              usage: LanguageModelV3Usage(inputTokens: 3, outputTokens: 2),
+              finishReason: LanguageModelV3FinishReason(unified: .stop),
+              usage: LanguageModelV3Usage(inputTokens: .init(total: 3), outputTokens: .init(total: 2)),
               providerMetadata: nil
             )
           ],

--- a/apps/docs/src/content/docs/foundations/providers-and-models.mdx
+++ b/apps/docs/src/content/docs/foundations/providers-and-models.mdx
@@ -24,7 +24,7 @@ The Swift AI SDK mirrors the AI SDK language-model specification (`AISDKProvider
 
 ## Swift AI SDK provider modules
 
-The Swift port currently ships with **37 provider modules** (one SwiftPM product per provider). Each module exports a lazily configured global shortcut plus a factory for advanced configuration, matching the TypeScript behavior. See [Providers](/providers/overview) for the full, up-to-date list.
+The Swift port currently ships with **38 provider modules** (one SwiftPM product per provider). Each module exports a lazily configured global shortcut plus a factory for advanced configuration, matching the TypeScript behavior. See [Providers](/providers/overview) for the full, up-to-date list.
 
 A few common examples:
 

--- a/apps/docs/src/content/docs/getting-started/navigating-the-library.mdx
+++ b/apps/docs/src/content/docs/getting-started/navigating-the-library.mdx
@@ -12,7 +12,7 @@ The Swift AI SDK is a comprehensive toolkit for building AI applications in Swif
 The Swift AI SDK ports the **AI SDK Core** from the TypeScript AI SDK, providing:
 
 - **AI SDK Core (SwiftAISDK):** Unified API for generating text, structured objects, and tool calls with LLMs
-- **Provider System:** Pre-built integrations for 37 provider modules (OpenAI, Anthropic, Google, Groq, Vercel, TogetherAI, and more). See [Providers](/providers/overview).
+- **Provider System:** Pre-built integrations for 38 provider modules (OpenAI, Anthropic, Google, Groq, Vercel, TogetherAI, and more). See [Providers](/providers/overview).
 - **Foundation Types (AISDKProvider):** Language model interfaces, provider protocols, and shared types
 - **Utilities (AISDKProviderUtils):** HTTP clients, JSON handling, schema validation, retry logic
 - **Zod Adapter (AISDKZodAdapter):** Zod-like schema DSL for structured data validation
@@ -43,7 +43,7 @@ The Swift AI SDK is organized into focused packages:
 | **AISDKZodAdapter**        | Zod-like schema DSL for structured data                    | AISDKProvider          |
 | **EventSourceParser**      | Server-Sent Events (SSE) parsing (internal utility)        | None                   |
 
-The list above is a sample. The Swift AI SDK ships with 37 provider modules; see [Providers](/providers/overview) for the full list.
+The list above is a sample. The Swift AI SDK ships with 38 provider modules; see [Providers](/providers/overview) for the full list.
 
 ## Platform Compatibility
 

--- a/apps/docs/src/content/docs/providers/alibaba.mdx
+++ b/apps/docs/src/content/docs/providers/alibaba.mdx
@@ -16,7 +16,7 @@ The Alibaba provider is available in the `AlibabaProvider` module. Add it to you
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/anthropic.mdx
+++ b/apps/docs/src/content/docs/providers/anthropic.mdx
@@ -16,7 +16,7 @@ The Anthropic provider is available in the `AnthropicProvider` module. Add it to
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/black-forest-labs.mdx
+++ b/apps/docs/src/content/docs/providers/black-forest-labs.mdx
@@ -14,7 +14,7 @@ The Black Forest Labs provider is available in the `BlackForestLabsProvider` mod
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/bytedance.mdx
+++ b/apps/docs/src/content/docs/providers/bytedance.mdx
@@ -16,7 +16,7 @@ The ByteDance provider is available in the `ByteDanceProvider` module. Add it to
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/cohere.mdx
+++ b/apps/docs/src/content/docs/providers/cohere.mdx
@@ -16,7 +16,7 @@ The Cohere provider is available in the `CohereProvider` module. Add it to your 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/fal.mdx
+++ b/apps/docs/src/content/docs/providers/fal.mdx
@@ -14,7 +14,7 @@ The Fal provider is available in the `FalProvider` module. Add it to your Swift 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/google-generative-ai.mdx
+++ b/apps/docs/src/content/docs/providers/google-generative-ai.mdx
@@ -17,7 +17,7 @@ The Google Generative AI provider is available in the `GoogleProvider` module. A
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/klingai.mdx
+++ b/apps/docs/src/content/docs/providers/klingai.mdx
@@ -16,7 +16,7 @@ The Kling AI provider is available in the `KlingAIProvider` module. Add it to yo
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/lmnt.mdx
+++ b/apps/docs/src/content/docs/providers/lmnt.mdx
@@ -14,7 +14,7 @@ Add the library via Swift Package Manager and include these products:
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/mistral.mdx
+++ b/apps/docs/src/content/docs/providers/mistral.mdx
@@ -16,7 +16,7 @@ The Mistral provider is available in the `MistralProvider` module. Add it to you
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/moonshotai.mdx
+++ b/apps/docs/src/content/docs/providers/moonshotai.mdx
@@ -16,7 +16,7 @@ The Moonshot AI provider is available in the `MoonshotAIProvider` module. Add it
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/open-responses.mdx
+++ b/apps/docs/src/content/docs/providers/open-responses.mdx
@@ -14,7 +14,7 @@ The Open Responses provider is available in the `OpenResponsesProvider` module. 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/openai.mdx
+++ b/apps/docs/src/content/docs/providers/openai.mdx
@@ -654,9 +654,9 @@ import OpenAIProvider
 
 let mcp = openai.tools.mcp(OpenAIMCPArgs(
   serverLabel: "zip1",
-  serverUrl: "https://zip1.io/mcp",
+  requireApproval: .always,
   serverDescription: "Link shortener",
-  requireApproval: .always
+  serverUrl: "https://zip1.io/mcp"
 ))
 
 let result = try streamText(

--- a/apps/docs/src/content/docs/providers/openai.mdx
+++ b/apps/docs/src/content/docs/providers/openai.mdx
@@ -16,7 +16,7 @@ The OpenAI provider is available in the `OpenAIProvider` module. Add it to your 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/overview.mdx
+++ b/apps/docs/src/content/docs/providers/overview.mdx
@@ -10,7 +10,7 @@ The AI SDK comes with several providers that you can use to interact with differ
 
 ## Swift provider modules
 
-The Swift AI SDK ships with **37 provider modules** (one SwiftPM product per provider). Documentation pages are still being ported for some providers.
+The Swift AI SDK ships with **38 provider modules** (one SwiftPM product per provider). Documentation pages are still being ported for some providers.
 
 | Provider | SwiftPM product | Docs |
 | --- | --- | --- |

--- a/apps/docs/src/content/docs/providers/perplexity.mdx
+++ b/apps/docs/src/content/docs/providers/perplexity.mdx
@@ -18,7 +18,7 @@ The Perplexity provider is available in the `PerplexityProvider` module. Add it 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/prodia.mdx
+++ b/apps/docs/src/content/docs/providers/prodia.mdx
@@ -14,7 +14,7 @@ The Prodia provider is available in the `ProdiaProvider` module. Add it to your 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/replicate.mdx
+++ b/apps/docs/src/content/docs/providers/replicate.mdx
@@ -15,7 +15,7 @@ Add the library via Swift Package Manager and include these products:
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/revai.mdx
+++ b/apps/docs/src/content/docs/providers/revai.mdx
@@ -14,7 +14,7 @@ The Rev.ai provider is available in the `RevAIProvider` module. Add it to your S
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/togetherai.mdx
+++ b/apps/docs/src/content/docs/providers/togetherai.mdx
@@ -14,7 +14,7 @@ The Together.ai provider is available in the `TogetherAIProvider` module. Add it
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/vercel.mdx
+++ b/apps/docs/src/content/docs/providers/vercel.mdx
@@ -27,7 +27,7 @@ The Vercel provider is available in the `VercelProvider` module. Add it to your 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.17.6")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.0")
 ],
 targets: [
   .target(

--- a/examples/Sources/AICoreExamples/GenerateText/OpenAIWarning.swift
+++ b/examples/Sources/AICoreExamples/GenerateText/OpenAIWarning.swift
@@ -43,12 +43,18 @@ struct GenerateTextOpenAIWarningExample: Example {
     switch warning {
     case .languageModel(let w):
       return describeLanguageWarning(w)
+    case .embeddingModel(let w):
+      return "Embedding model warning: \(describeLanguageWarning(w))"
     case .imageModel(let w):
-      return "Image model warning: \(String(describing: w))"
+      return "Image model warning: \(describeLanguageWarning(w))"
+    case .videoModel(let w):
+      return "Video model warning: \(describeLanguageWarning(w))"
     case .speechModel(let w):
-      return "Speech model warning: \(String(describing: w))"
+      return "Speech model warning: \(describeLanguageWarning(w))"
     case .transcriptionModel(let w):
-      return "Transcription warning: \(String(describing: w))"
+      return "Transcription warning: \(describeLanguageWarning(w))"
+    case .rerankingModel(let w):
+      return "Reranking model warning: \(describeLanguageWarning(w))"
     }
   }
 
@@ -56,21 +62,16 @@ struct GenerateTextOpenAIWarningExample: Example {
     return "Language model warning: \(describeLanguageWarning(warning))"
   }
 
-  private static func describeLanguageWarning(_ warning: LanguageModelV3CallWarning) -> String {
+  private static func describeLanguageWarning(_ warning: CallWarning) -> String {
     switch warning {
-    case .unsupportedSetting(let setting, let details):
-      if let details { return "Unsupported setting \(setting): \(details)" }
-      return "Unsupported setting \(setting)"
-    case .unsupportedTool(let tool, let details):
-      let toolName: String
-      switch tool {
-      case .function(let functionTool):
-        toolName = functionTool.name
-      case .providerDefined:
-        toolName = "provider-defined tool"
-      }
-      if let details { return "Unsupported tool \(toolName): \(details)" }
-      return "Unsupported tool \(toolName)"
+    case .unsupported(let feature, let details):
+      if let details { return "Unsupported feature \(feature): \(details)" }
+      return "Unsupported feature \(feature)"
+    case .compatibility(let feature, let details):
+      if let details { return "Compatibility warning \(feature): \(details)" }
+      return "Compatibility warning \(feature)"
+    case .deprecated(let setting, let message):
+      return "Deprecated setting \(setting): \(message)"
     case .other(let message):
       return message
     }

--- a/examples/Sources/AICoreExamples/Registry/RegistryEmbedOpenAI.swift
+++ b/examples/Sources/AICoreExamples/Registry/RegistryEmbedOpenAI.swift
@@ -12,7 +12,7 @@ struct RegistryEmbedOpenAIExample: Example {
         "openai": createOpenAIProvider()
       ])
 
-      let model = registry.textEmbeddingModel(id: "openai:text-embedding-3-small")
+      let model = try registry.textEmbeddingModel(id: "openai:text-embedding-3-small")
       let text = "sunny day at the beach"
       let result = try await embed(model: model, value: text)
       Logger.section("Embedding (first 8 dims)")

--- a/examples/Sources/AICoreExamples/Registry/RegistryGenerateImageOpenAI.swift
+++ b/examples/Sources/AICoreExamples/Registry/RegistryGenerateImageOpenAI.swift
@@ -12,7 +12,7 @@ struct RegistryGenerateImageOpenAIExample: Example {
         "openai": createOpenAIProvider()
       ])
 
-      let model = registry.imageModel(id: "openai:gpt-image-1-mini")
+      let model = try registry.imageModel(id: "openai:gpt-image-1-mini")
       let result = try await generateImage(
         model: model,
         prompt: "A simple sketch of a paper airplane, monochrome"

--- a/examples/Sources/AICoreExamples/Registry/RegistryStreamTextOpenAI.swift
+++ b/examples/Sources/AICoreExamples/Registry/RegistryStreamTextOpenAI.swift
@@ -12,9 +12,9 @@ struct RegistryStreamTextOpenAIExample: Example {
         "openai": createOpenAIProvider()
       ])
 
-      let model = registry.languageModel(id: "openai:gpt-4o")
-      let result = try streamText(
-        model: model,
+      let model = try registry.languageModel(id: "openai:gpt-4o")
+      let result: DefaultStreamTextResult<JSONValue, JSONValue> = try streamText(
+        model: .v4(model),
         prompt: "Say hello from the registry stream example."
       )
 

--- a/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIOnChunkToolCallStreaming.swift
+++ b/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIOnChunkToolCallStreaming.swift
@@ -32,7 +32,7 @@ struct StreamTextOpenAIOnChunkToolCallStreamingExample: Example {
         tools: ["weather": weather.tool],
         onChunk: { part in
           switch part {
-          case .toolInputStart(let id, let toolName, _, _, _):
+          case .toolInputStart(let id, let toolName, _, _, _, _):
             Logger.info("toolInputStart id=\(id) tool=\(toolName)")
           case .toolInputDelta(let id, let delta, _):
             Logger.info("toolInputDelta id=\(id) delta=\(delta.prefix(60))...")

--- a/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesCodeInterpreter.swift
+++ b/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesCodeInterpreter.swift
@@ -10,8 +10,6 @@ struct StreamTextOpenAIResponsesCodeInterpreterExample: Example {
     do {
       let codeTool = openai.tools.codeInterpreter()
 
-      let providerOptions = openai.options.responses(include: [.codeInterpreterCallOutputs])
-
       let result = try streamText(
         model: openai.responses("gpt-4.1-mini"),
         system: "Use the code interpreter when math or CSV processing is needed.",
@@ -20,8 +18,7 @@ struct StreamTextOpenAIResponsesCodeInterpreterExample: Example {
         ],
         tools: [
           "code_interpreter": codeTool
-        ],
-        providerOptions: providerOptions
+        ]
       )
 
       Logger.section("Streamed output")

--- a/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesMCPTool.swift
+++ b/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesMCPTool.swift
@@ -18,9 +18,9 @@ struct StreamTextOpenAIResponsesMCPToolExample: Example {
     do {
       let mcp = openai.tools.mcp(.init(
         serverLabel: "zip1",
-        serverUrl: resolvedServerUrl,
+        requireApproval: .always,
         serverDescription: "Link shortener",
-        requireApproval: .always
+        serverUrl: resolvedServerUrl,
       ))
 
       let result = try streamText(
@@ -55,13 +55,13 @@ struct StreamTextOpenAIResponsesMCPToolExample: Example {
           Logger.section("TOOL RESULT \(result.toolName)")
           Helpers.printJSON(result.output)
 
-        case .finishStep(_, let usage, let finishReason, _):
+        case .finishStep(_, let usage, let finishReason, _, _):
           Logger.section("STEP FINISH")
           Logger.info("Finish reason: \(finishReason.rawValue)")
           Helpers.printJSON(usage)
           print("")
 
-        case .finish(let finishReason, let totalUsage):
+        case .finish(let finishReason, _, let totalUsage):
           Logger.section("FINISH")
           Logger.info("Finish reason: \(finishReason.rawValue)")
           Helpers.printJSON(totalUsage)
@@ -79,4 +79,3 @@ struct StreamTextOpenAIResponsesMCPToolExample: Example {
     }
   }
 }
-

--- a/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesReasoningToolCall.swift
+++ b/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesReasoningToolCall.swift
@@ -91,7 +91,7 @@ struct StreamTextOpenAIResponsesReasoningToolCallExample: Example {
         case .reasoningEnd:
           print("\u{001B}[0m")
 
-        case .toolInputStart(_, let toolName, _, _, _):
+        case .toolInputStart(_, let toolName, _, _, _, _):
           print("\u{001B}[33mTool call: \(toolName)")
           print("Tool args: ", terminator: "")
         case .toolInputDelta(_, let delta, _):
@@ -114,13 +114,13 @@ struct StreamTextOpenAIResponsesReasoningToolCallExample: Example {
         case .textEnd:
           print("\u{001B}[0m")
 
-        case .finishStep(_, let usage, let finishReason, _):
+        case .finishStep(_, let usage, let finishReason, _, _):
           Logger.info("Finish reason: \(finishReason.rawValue)")
           Logger.info("Usage:")
           Helpers.printJSON(usage)
           Logger.info("STEP FINISH")
 
-        case .finish(let finishReason, let totalUsage):
+        case .finish(let finishReason, _, let totalUsage):
           Logger.info("Finish reason: \(finishReason.rawValue)")
           Logger.info("Total usage:")
           Helpers.printJSON(totalUsage)

--- a/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesToolCall.swift
+++ b/examples/Sources/AICoreExamples/StreamText/StreamTextOpenAIResponsesToolCall.swift
@@ -57,13 +57,13 @@ struct StreamTextOpenAIResponsesToolCallExample: Example {
           Logger.section("TOOL RESULT \(result.toolName)")
           Helpers.printJSON(result.output)
 
-        case .finishStep(_, let usage, let finishReason, _):
+        case .finishStep(_, let usage, let finishReason, _, _):
           Logger.section("STEP FINISH")
           Logger.info("Finish reason: \(finishReason.rawValue)")
           Helpers.printJSON(usage)
           print("")
 
-        case .finish(let finishReason, let totalUsage):
+        case .finish(let finishReason, _, let totalUsage):
           Logger.section("FINISH")
           Logger.info("Finish reason: \(finishReason.rawValue)")
           Helpers.printJSON(totalUsage)

--- a/examples/Sources/ProviderManagementExample/main.swift
+++ b/examples/Sources/ProviderManagementExample/main.swift
@@ -64,15 +64,15 @@ struct ProviderManagementExample: CLIExample {
     )
 
     Logger.info("Accessing model via registry: 'openai:gpt-4o-mini'")
-    let registryResult = try await generateText(
-      model: registry.languageModel(id: "openai:gpt-4o-mini"),
+    let registryResult: DefaultGenerateTextResult<JSONValue> = try await generateText(
+      model: .v4(registry.languageModel(id: "openai:gpt-4o-mini")),
       prompt: "Say hello in Spanish"
     )
     Logger.info(registryResult.text)
 
     Logger.info("Accessing custom provider model: 'custom:fast'")
-    let customResult = try await generateText(
-      model: registry.languageModel(id: "custom:fast"),
+    let customResult: DefaultGenerateTextResult<JSONValue> = try await generateText(
+      model: .v4(registry.languageModel(id: "custom:fast")),
       prompt: "Say hello in French"
     )
     Logger.info(customResult.text)
@@ -90,8 +90,8 @@ struct ProviderManagementExample: CLIExample {
     )
 
     Logger.info("Accessing model: 'openai > gpt-4o'")
-    let separatorResult = try await generateText(
-      model: readableRegistry.languageModel(id: "openai > gpt-4o"),
+    let separatorResult: DefaultGenerateTextResult<JSONValue> = try await generateText(
+      model: .v4(readableRegistry.languageModel(id: "openai > gpt-4o")),
       prompt: "What is Swift?"
     )
     Logger.info(separatorResult.text.prefix(100) + "...")
@@ -114,8 +114,8 @@ struct ProviderManagementExample: CLIExample {
     )
 
     Logger.info("All models from this registry extract <think> tags:")
-    let thinkResult = try await generateText(
-      model: middlewareRegistry.languageModel(id: "openai:gpt-4o"),
+    let thinkResult: DefaultGenerateTextResult<JSONValue> = try await generateText(
+      model: .v4(middlewareRegistry.languageModel(id: "openai:gpt-4o")),
       prompt: "Calculate 15 * 7. Wrap your reasoning in <think> tags."
     )
 

--- a/examples/Sources/TestingExample/main.swift
+++ b/examples/Sources/TestingExample/main.swift
@@ -25,10 +25,10 @@ struct TestingExample: CLIExample {
       doGenerate: .function { _ in
         LanguageModelV3GenerateResult(
           content: [.text(LanguageModelV3Text(text: "Hello, world!"))],
-          finishReason: .stop,
+          finishReason: LanguageModelV3FinishReason(unified: .stop),
           usage: LanguageModelV3Usage(
-            inputTokens: 10,
-            outputTokens: 20
+            inputTokens: .init(total: 10),
+            outputTokens: .init(total: 20)
           )
         )
       }
@@ -57,10 +57,10 @@ struct TestingExample: CLIExample {
               .textDelta(id: "text-1", delta: "world!", providerMetadata: nil),
               .textEnd(id: "text-1", providerMetadata: nil),
               .finish(
-                finishReason: .stop,
+                finishReason: LanguageModelV3FinishReason(unified: .stop),
                 usage: LanguageModelV3Usage(
-                  inputTokens: 3,
-                  outputTokens: 10
+                  inputTokens: .init(total: 3),
+                  outputTokens: .init(total: 10)
                 ),
                 providerMetadata: nil
               )
@@ -91,8 +91,8 @@ struct TestingExample: CLIExample {
       doGenerate: .function { _ in
         LanguageModelV3GenerateResult(
           content: [.text(LanguageModelV3Text(text: "Response"))],
-          finishReason: .stop,
-          usage: LanguageModelV3Usage(inputTokens: 5, outputTokens: 5)
+          finishReason: LanguageModelV3FinishReason(unified: .stop),
+          usage: LanguageModelV3Usage(inputTokens: .init(total: 5), outputTokens: .init(total: 5))
         )
       }
     )
@@ -116,8 +116,8 @@ struct TestingExample: CLIExample {
       doGenerate: .function { _ in
         LanguageModelV3GenerateResult(
           content: [.text(LanguageModelV3Text(text: "Complete"))],
-          finishReason: .stop,
-          usage: LanguageModelV3Usage(inputTokens: 3, outputTokens: 2)
+          finishReason: LanguageModelV3FinishReason(unified: .stop),
+          usage: LanguageModelV3Usage(inputTokens: .init(total: 3), outputTokens: .init(total: 2))
         )
       }
     )
@@ -126,8 +126,8 @@ struct TestingExample: CLIExample {
       doGenerate: .function { _ in
         LanguageModelV3GenerateResult(
           content: [.text(LanguageModelV3Text(text: "Truncated..."))],
-          finishReason: .length,
-          usage: LanguageModelV3Usage(inputTokens: 3, outputTokens: 100)
+          finishReason: LanguageModelV3FinishReason(unified: .length),
+          usage: LanguageModelV3Usage(inputTokens: .init(total: 3), outputTokens: .init(total: 100))
         )
       }
     )
@@ -147,13 +147,13 @@ struct TestingExample: CLIExample {
     let mockResponses = mockValues(
       LanguageModelV3GenerateResult(
         content: [.text(LanguageModelV3Text(text: "First response"))],
-        finishReason: .stop,
-        usage: LanguageModelV3Usage(inputTokens: 10, outputTokens: 5)
+        finishReason: LanguageModelV3FinishReason(unified: .stop),
+        usage: LanguageModelV3Usage(inputTokens: .init(total: 10), outputTokens: .init(total: 5))
       ),
       LanguageModelV3GenerateResult(
         content: [.text(LanguageModelV3Text(text: "Second response"))],
-        finishReason: .stop,
-        usage: LanguageModelV3Usage(inputTokens: 10, outputTokens: 5)
+        finishReason: LanguageModelV3FinishReason(unified: .stop),
+        usage: LanguageModelV3Usage(inputTokens: .init(total: 10), outputTokens: .init(total: 5))
       )
     )
 
@@ -189,8 +189,8 @@ struct TestingExample: CLIExample {
               .textDelta(id: "text-1", delta: " stream", providerMetadata: nil),
               .textEnd(id: "text-1", providerMetadata: nil),
               .finish(
-                finishReason: .stop,
-                usage: LanguageModelV3Usage(inputTokens: 3, outputTokens: 2),
+                finishReason: LanguageModelV3FinishReason(unified: .stop),
+                usage: LanguageModelV3Usage(inputTokens: .init(total: 3), outputTokens: .init(total: 2)),
                 providerMetadata: nil
               )
             ],

--- a/upstream/PROGRESS.md
+++ b/upstream/PROGRESS.md
@@ -40,9 +40,13 @@ Status:
 
 Latest validation:
 - `2026-07-02`: `AGENT=1 swift test`
-  passed all 3967 Swift Testing tests.
-- `2026-07-02`: `AGENT=1 node tools/test-runner.js --config tools/test-runner.default.config.json`
-  passed all 3967 selected tests.
+  passed all 3973 Swift Testing tests.
+- `2026-07-02`: `node tools/test-runner.js --config tools/test-runner.default.config.json`
+  passed all 3973 selected tests.
+- `2026-07-02`: `pnpm run examples:build`
+  built the examples package successfully.
+- `2026-07-02`: `pnpm run docs:check` and `pnpm run docs:build`
+  passed; the docs build generated 53 pages.
 
 ## Known gaps / TODO
 
@@ -1776,6 +1780,16 @@ This is a lightweight “memory log” of what we shipped while chasing upstream
 For source-of-truth code, always follow the commits and tests.
 
 ### Unreleased (main)
+
+No unreleased parity changes yet.
+
+### v0.18.0 - 2026-07-02
+
+- 2026-07-02
+  - Core V4 foundation on refreshed upstream `85a80fc6e71558717899e30c9f1fc0e9eb7d733d`: added `ProviderV4` plus V4 language, embedding, image, speech, transcription, video, reranking, realtime, middleware, file, skill, warning, provider-reference, and shared file-data contracts; high-level Swift AI SDK flows now run through V4-compatible adapters while preserving V3/V2 provider compatibility.
+  - Provider utils V4 foundation on refreshed upstream `85a80fc6e71558717899e30c9f1fc0e9eb7d733d`: added shared provider-reference resolution, reasoning mapping, normalized headers, origin/filename/media helpers, inline data conversion, multipart form-data support, validated downloads, size-limited reads, model option serialization, streaming tool-call tracking, provider tool-name mapping, standard-schema normalization, response cancellation, delayed promises, and browser runtime detection.
+  - OpenAI-compatible V4 surface: added V4 adapters and regression coverage for OpenAI-compatible chat models, including reasoning-content round-trips.
+  - Release/CI: tracked the V4 skills contract files and root-scoped the local `skills/` ignore rule so protected GitHub checkouts build the same source tree as local development.
 
 - 2026-04-15
   - Anthropic upload parity on refreshed upstream `4891db8bfc583d3767831dac83439ac190c93cb0`: added provider-side `files()` / `skills()` surfaces with multipart upload support (`AnthropicFiles`, `AnthropicSkills`), including `files-api-2025-04-14` / `skills-2025-10-02` beta headers, version-metadata fetch for uploaded skills, and direct regression coverage for multipart payloads plus mapped provider metadata.


### PR DESCRIPTION
## Summary
- refresh public examples and docs snippets for current V4 registry/streaming/provider warning APIs
- bump release references to 0.18.0 across README, docs, and SDK release version
- add v0.18.0 changelog and upstream parity progress evidence

## Validation
- swift build
- AGENT=1 swift test (3973 tests)
- node tools/test-runner.js --config tools/test-runner.default.config.json (3973 tests)
- pnpm run examples:build
- pnpm run docs:check
- pnpm run docs:build (53 pages)
- git diff --check