### PR TITLE
fix(google): normalize video polling aborts

### DIFF
--- a/Sources/GoogleProvider/GoogleGenerativeAIVideoModel.swift
+++ b/Sources/GoogleProvider/GoogleGenerativeAIVideoModel.swift
@@ -402,18 +402,26 @@ public final class GoogleGenerativeAIVideoModel: VideoModelV3 {
             combineHeaders(try self.config.headers(), options.headers?.mapValues { Optional($0) }).compactMapValues { $0 }
         }
 
-        let operation = try await postJsonToAPI(
-            url: "\(config.baseURL)/models/\(modelIdentifier.rawValue):predictLongRunning",
-            headers: requestHeaders(),
-            body: JSONValue.object([
-                "instances": .array([.object(instance)]),
-                "parameters": .object(parameters)
-            ]),
-            failedResponseHandler: googleFailedResponseHandler,
-            successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVideoOperationSchema),
-            isAborted: options.abortSignal,
-            fetch: config.fetch
-        )
+        let operation: ResponseHandlerResult<GoogleVideoOperation>
+        do {
+            operation = try await postJsonToAPI(
+                url: "\(config.baseURL)/models/\(modelIdentifier.rawValue):predictLongRunning",
+                headers: requestHeaders(),
+                body: JSONValue.object([
+                    "instances": .array([.object(instance)]),
+                    "parameters": .object(parameters)
+                ]),
+                failedResponseHandler: googleFailedResponseHandler,
+                successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVideoOperationSchema),
+                isAborted: options.abortSignal,
+                fetch: config.fetch
+            )
+        } catch {
+            if isVideoGenerationAbort(error, abortSignal: options.abortSignal) {
+                throw googleVideoGenerationAbortedError()
+            }
+            throw error
+        }
 
         guard let operationName = operation.value.name, !operationName.isEmpty else {
             throw GoogleVideoModelError(
@@ -438,27 +446,31 @@ public final class GoogleGenerativeAIVideoModel: VideoModelV3 {
                 )
             }
 
-            let pollDelay = max(0, Int(pollIntervalMs.rounded(.towardZero)))
-            try await delay(pollDelay)
+            do {
+                let pollDelay = max(0, Int(pollIntervalMs.rounded(.towardZero)))
+                try await delay(pollDelay, abortSignal: options.abortSignal)
 
-            if options.abortSignal?() == true {
-                throw GoogleVideoModelError(
-                    name: "GOOGLE_VIDEO_GENERATION_ABORTED",
-                    message: "Video generation request was aborted"
+                if options.abortSignal?() == true {
+                    throw googleVideoGenerationAbortedError()
+                }
+
+                let statusOperation = try await getFromAPI(
+                    url: "\(config.baseURL)/\(operationName)",
+                    headers: requestHeaders(),
+                    failedResponseHandler: googleFailedResponseHandler,
+                    successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVideoOperationSchema),
+                    isAborted: options.abortSignal,
+                    fetch: config.fetch
                 )
+
+                finalOperation = statusOperation.value
+                responseHeaders = statusOperation.responseHeaders
+            } catch {
+                if isVideoGenerationAbort(error, abortSignal: options.abortSignal) {
+                    throw googleVideoGenerationAbortedError()
+                }
+                throw error
             }
-
-            let statusOperation = try await getFromAPI(
-                url: "\(config.baseURL)/\(operationName)",
-                headers: requestHeaders(),
-                failedResponseHandler: googleFailedResponseHandler,
-                successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVideoOperationSchema),
-                isAborted: options.abortSignal,
-                fetch: config.fetch
-            )
-
-            finalOperation = statusOperation.value
-            responseHeaders = statusOperation.responseHeaders
         }
 
         if let operationError = finalOperation.error {
@@ -535,6 +547,20 @@ private func formatMilliseconds(_ value: Double) -> String {
         return String(Int(value))
     }
     return String(value)
+}
+
+private func isVideoGenerationAbort(
+    _ error: Error,
+    abortSignal: (@Sendable () -> Bool)?
+) -> Bool {
+    abortSignal?() == true && isAbortError(error)
+}
+
+private func googleVideoGenerationAbortedError() -> GoogleVideoModelError {
+    GoogleVideoModelError(
+        name: "GOOGLE_VIDEO_GENERATION_ABORTED",
+        message: "Video generation request was aborted"
+    )
 }
 
 private struct GoogleVideoModelError: AISDKError, Sendable {

--- a/Sources/GoogleVertexProvider/GoogleVertexVideoModel.swift
+++ b/Sources/GoogleVertexProvider/GoogleVertexVideoModel.swift
@@ -428,18 +428,26 @@ public final class GoogleVertexVideoModel: VideoModelV3 {
             combineHeaders(try self.config.headers(), options.headers?.mapValues { Optional($0) }).compactMapValues { $0 }
         }
 
-        let operation = try await postJsonToAPI(
-            url: "\(config.baseURL)/models/\(modelIdentifier.rawValue):predictLongRunning",
-            headers: requestHeaders(),
-            body: JSONValue.object([
-                "instances": .array([.object(instance)]),
-                "parameters": .object(parameters)
-            ]),
-            failedResponseHandler: googleVertexFailedResponseHandler,
-            successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVertexVideoOperationSchema),
-            isAborted: options.abortSignal,
-            fetch: config.fetch
-        )
+        let operation: ResponseHandlerResult<GoogleVertexVideoOperation>
+        do {
+            operation = try await postJsonToAPI(
+                url: "\(config.baseURL)/models/\(modelIdentifier.rawValue):predictLongRunning",
+                headers: requestHeaders(),
+                body: JSONValue.object([
+                    "instances": .array([.object(instance)]),
+                    "parameters": .object(parameters)
+                ]),
+                failedResponseHandler: googleVertexFailedResponseHandler,
+                successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVertexVideoOperationSchema),
+                isAborted: options.abortSignal,
+                fetch: config.fetch
+            )
+        } catch {
+            if isVideoGenerationAbort(error, abortSignal: options.abortSignal) {
+                throw googleVertexVideoGenerationAbortedError()
+            }
+            throw error
+        }
 
         guard let operationName = operation.value.name, !operationName.isEmpty else {
             throw GoogleVertexVideoModelError(
@@ -464,30 +472,34 @@ public final class GoogleVertexVideoModel: VideoModelV3 {
                 )
             }
 
-            let pollDelay = max(0, Int(pollIntervalMs.rounded(.towardZero)))
-            try await delay(pollDelay)
+            do {
+                let pollDelay = max(0, Int(pollIntervalMs.rounded(.towardZero)))
+                try await delay(pollDelay, abortSignal: options.abortSignal)
 
-            if options.abortSignal?() == true {
-                throw GoogleVertexVideoModelError(
-                    name: "VERTEX_VIDEO_GENERATION_ABORTED",
-                    message: "Video generation request was aborted"
+                if options.abortSignal?() == true {
+                    throw googleVertexVideoGenerationAbortedError()
+                }
+
+                let statusOperation = try await postJsonToAPI(
+                    url: "\(config.baseURL)/models/\(modelIdentifier.rawValue):fetchPredictOperation",
+                    headers: requestHeaders(),
+                    body: JSONValue.object([
+                        "operationName": .string(operationName)
+                    ]),
+                    failedResponseHandler: googleVertexFailedResponseHandler,
+                    successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVertexVideoOperationSchema),
+                    isAborted: options.abortSignal,
+                    fetch: config.fetch
                 )
+
+                finalOperation = statusOperation.value
+                responseHeaders = statusOperation.responseHeaders
+            } catch {
+                if isVideoGenerationAbort(error, abortSignal: options.abortSignal) {
+                    throw googleVertexVideoGenerationAbortedError()
+                }
+                throw error
             }
-
-            let statusOperation = try await postJsonToAPI(
-                url: "\(config.baseURL)/models/\(modelIdentifier.rawValue):fetchPredictOperation",
-                headers: requestHeaders(),
-                body: JSONValue.object([
-                    "operationName": .string(operationName)
-                ]),
-                failedResponseHandler: googleVertexFailedResponseHandler,
-                successfulResponseHandler: createJsonResponseHandler(responseSchema: googleVertexVideoOperationSchema),
-                isAborted: options.abortSignal,
-                fetch: config.fetch
-            )
-
-            finalOperation = statusOperation.value
-            responseHeaders = statusOperation.responseHeaders
         }
 
         if let operationError = finalOperation.error {
@@ -573,6 +585,20 @@ private func formatVertexMilliseconds(_ value: Double) -> String {
         return String(Int(value))
     }
     return String(value)
+}
+
+private func isVideoGenerationAbort(
+    _ error: Error,
+    abortSignal: (@Sendable () -> Bool)?
+) -> Bool {
+    abortSignal?() == true && isAbortError(error)
+}
+
+private func googleVertexVideoGenerationAbortedError() -> GoogleVertexVideoModelError {
+    GoogleVertexVideoModelError(
+        name: "VERTEX_VIDEO_GENERATION_ABORTED",
+        message: "Video generation request was aborted"
+    )
 }
 
 private struct GoogleVertexVideoModelError: AISDKError, Sendable {

--- a/Tests/GoogleProviderTests/GoogleGenerativeAIVideoModelTests.swift
+++ b/Tests/GoogleProviderTests/GoogleGenerativeAIVideoModelTests.swift
@@ -1216,10 +1216,8 @@ struct GoogleGenerativeAIVideoModelTests {
             }
 
             if urlString.contains("/operations/abort-test") {
-                Task {
-                    try? await Task.sleep(nanoseconds: 60_000_000)
-                    flag.abort()
-                }
+                flag.abort()
+                try await Task.sleep(nanoseconds: 120_000_000)
                 let response = try self.jsonData([
                     "name": "operations/abort-test",
                     "done": false
@@ -1240,7 +1238,7 @@ struct GoogleGenerativeAIVideoModelTests {
             _ = try await model.doGenerate(options: makeOptions(
                 providerOptions: [
                     "google": [
-                        "pollIntervalMs": .number(100)
+                        "pollIntervalMs": .number(1)
                     ]
                 ],
                 abortSignal: { flag.isAborted() }

--- a/Tests/GoogleVertexProviderTests/GoogleVertexVideoModelTests.swift
+++ b/Tests/GoogleVertexProviderTests/GoogleVertexVideoModelTests.swift
@@ -1187,10 +1187,8 @@ struct GoogleVertexVideoModelTests {
             }
 
             if urlString.contains(":fetchPredictOperation") {
-                Task {
-                    try? await Task.sleep(nanoseconds: 60_000_000)
-                    flag.abort()
-                }
+                flag.abort()
+                try await Task.sleep(nanoseconds: 120_000_000)
                 let response = try self.jsonData([
                     "name": "operations/abort-test",
                     "done": false
@@ -1211,7 +1209,7 @@ struct GoogleVertexVideoModelTests {
             _ = try await model.doGenerate(options: makeOptions(
                 providerOptions: [
                     "vertex": [
-                        "pollIntervalMs": .number(100)
+                        "pollIntervalMs": .number(1)
                     ]
                 ],
                 abortSignal: { flag.isAborted() }


### PR DESCRIPTION
## Summary
- Normalize abort-triggered CancellationError during Google and Google Vertex video polling into provider-level aborted errors.
- Pass abort signals into polling delay so aborted calls stop during delay, not only before the next request.
- Make Google/Vertex abort tests deterministic by exercising the polling fetch abort boundary that failed on main CI.

## Validation
- swift test --enable-code-coverage --parallel --filter pollingAbort
- swift test --enable-code-coverage --parallel --filter GoogleVertexVideoModelTests
- swift test --enable-code-coverage --parallel --filter GoogleGenerativeAIVideoModelTests
- AGENT=1 swift test
- swift test --enable-code-coverage --parallel
- swift build
- git diff --check