### PR TITLE
chore(release): prepare v0.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Add the package to your `Package.swift`:
 ```swift
 // Package.swift
 dependencies: [
-  // Use the latest release tag (e.g. "0.18.1").
-  .package(url: "https://github.com/teunlao/swift-ai-sdk.git", from: "0.18.1")
+  // Use the latest release tag (e.g. "0.18.2").
+  .package(url: "https://github.com/teunlao/swift-ai-sdk.git", from: "0.18.2")
 ],
 targets: [
   .target(
@@ -122,7 +122,7 @@ let summary = try await generateObject(
   model: openai("gpt-5"),
   schema: Release.self,
   schemaName: "release_summary",
-  prompt: "Summarize Swift AI SDK 0.18.1: streaming + tools."
+  prompt: "Summarize Swift AI SDK 0.18.2: streaming + tools."
 ).object
 
 print("Release: \\(summary.name) (\\(summary.version))")

--- a/Sources/AISDKProviderUtils/Versioning/SDKReleaseVersion.swift
+++ b/Sources/AISDKProviderUtils/Versioning/SDKReleaseVersion.swift
@@ -3,5 +3,5 @@ import Foundation
 /// Shared release version used across all providers.
 public enum SDKReleaseVersion {
     /// Returns the release version string.
-    public static let value: String = "0.18.1"
+    public static let value: String = "0.18.2"
 }

--- a/apps/docs/src/content/docs/providers/alibaba.mdx
+++ b/apps/docs/src/content/docs/providers/alibaba.mdx
@@ -16,7 +16,7 @@ The Alibaba provider is available in the `AlibabaProvider` module. Add it to you
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/anthropic.mdx
+++ b/apps/docs/src/content/docs/providers/anthropic.mdx
@@ -16,7 +16,7 @@ The Anthropic provider is available in the `AnthropicProvider` module. Add it to
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/black-forest-labs.mdx
+++ b/apps/docs/src/content/docs/providers/black-forest-labs.mdx
@@ -14,7 +14,7 @@ The Black Forest Labs provider is available in the `BlackForestLabsProvider` mod
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/bytedance.mdx
+++ b/apps/docs/src/content/docs/providers/bytedance.mdx
@@ -16,7 +16,7 @@ The ByteDance provider is available in the `ByteDanceProvider` module. Add it to
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/cohere.mdx
+++ b/apps/docs/src/content/docs/providers/cohere.mdx
@@ -16,7 +16,7 @@ The Cohere provider is available in the `CohereProvider` module. Add it to your 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/fal.mdx
+++ b/apps/docs/src/content/docs/providers/fal.mdx
@@ -14,7 +14,7 @@ The Fal provider is available in the `FalProvider` module. Add it to your Swift 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/google-generative-ai.mdx
+++ b/apps/docs/src/content/docs/providers/google-generative-ai.mdx
@@ -17,7 +17,7 @@ The Google Generative AI provider is available in the `GoogleProvider` module. A
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/klingai.mdx
+++ b/apps/docs/src/content/docs/providers/klingai.mdx
@@ -16,7 +16,7 @@ The Kling AI provider is available in the `KlingAIProvider` module. Add it to yo
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/lmnt.mdx
+++ b/apps/docs/src/content/docs/providers/lmnt.mdx
@@ -14,7 +14,7 @@ Add the library via Swift Package Manager and include these products:
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/mistral.mdx
+++ b/apps/docs/src/content/docs/providers/mistral.mdx
@@ -16,7 +16,7 @@ The Mistral provider is available in the `MistralProvider` module. Add it to you
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/moonshotai.mdx
+++ b/apps/docs/src/content/docs/providers/moonshotai.mdx
@@ -16,7 +16,7 @@ The Moonshot AI provider is available in the `MoonshotAIProvider` module. Add it
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/open-responses.mdx
+++ b/apps/docs/src/content/docs/providers/open-responses.mdx
@@ -14,7 +14,7 @@ The Open Responses provider is available in the `OpenResponsesProvider` module. 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/openai.mdx
+++ b/apps/docs/src/content/docs/providers/openai.mdx
@@ -16,7 +16,7 @@ The OpenAI provider is available in the `OpenAIProvider` module. Add it to your 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/perplexity.mdx
+++ b/apps/docs/src/content/docs/providers/perplexity.mdx
@@ -18,7 +18,7 @@ The Perplexity provider is available in the `PerplexityProvider` module. Add it 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+    .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
     .target(

--- a/apps/docs/src/content/docs/providers/prodia.mdx
+++ b/apps/docs/src/content/docs/providers/prodia.mdx
@@ -14,7 +14,7 @@ The Prodia provider is available in the `ProdiaProvider` module. Add it to your 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/replicate.mdx
+++ b/apps/docs/src/content/docs/providers/replicate.mdx
@@ -15,7 +15,7 @@ Add the library via Swift Package Manager and include these products:
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/revai.mdx
+++ b/apps/docs/src/content/docs/providers/revai.mdx
@@ -14,7 +14,7 @@ The Rev.ai provider is available in the `RevAIProvider` module. Add it to your S
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/togetherai.mdx
+++ b/apps/docs/src/content/docs/providers/togetherai.mdx
@@ -14,7 +14,7 @@ The Together.ai provider is available in the `TogetherAIProvider` module. Add it
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/apps/docs/src/content/docs/providers/vercel.mdx
+++ b/apps/docs/src/content/docs/providers/vercel.mdx
@@ -27,7 +27,7 @@ The Vercel provider is available in the `VercelProvider` module. Add it to your 
 ```swift
 // Package.swift (excerpt)
 dependencies: [
-  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.1")
+  .package(url: "https://github.com/teunlao/swift-ai-sdk", from: "0.18.2")
 ],
 targets: [
   .target(

--- a/upstream/PROGRESS.md
+++ b/upstream/PROGRESS.md
@@ -2530,6 +2530,12 @@ For source-of-truth code, always follow the commits and tests.
 
 ### Unreleased (main)
 
+### v0.18.2 - 2026-07-04
+
+- 2026-07-04
+  - Release/CI: `v0.18.2` supersedes `v0.18.1` on the same OpenAI V4 release line after normalizing Google and Google Vertex video polling abort races to provider abort errors instead of leaking raw Swift `CancellationError`.
+  - Release/docs: README, SDK release version, Starlight install snippets, changelog, and upstream evidence now point at `0.18.2`.
+
 - 2026-07-04
   - OpenAI package source-owner closure on refreshed upstream `c8d2726ae045a28142cb46df5e41cdd51d8dcc71`: the remaining runtime source owners are now tracked or classified (`openai-chat-prompt.ts`, files/skills API schemas, `openai-config.ts`, realtime export aliases, and TypeScript-only internal re-exports), and the broad OpenAI provider audit status now points at the refreshed upstream commit.
   - Validation: `swift test --filter 'OpenAIFilesSkillsTests|OpenAIProviderTests|OpenAIRealtimeModelTests|OpenAIChatMessagesConverterTests'` passed 49 Swift Testing tests.


### PR DESCRIPTION
## Summary
- bump shared SDK release version to 0.18.2
- update README and Starlight provider install snippets to 0.18.2
- record v0.18.2 release notes in upstream progress after the Google video abort CI hotfix

## Validation
- swift build
- pnpm run docs:check
- pnpm run docs:build
- git diff --check