### PR TITLE
test(alibaba): stabilize video base URL coverage

### DIFF
--- a/Tests/AlibabaProviderTests/AlibabaProviderTests.swift
+++ b/Tests/AlibabaProviderTests/AlibabaProviderTests.swift
@@ -192,7 +192,7 @@ struct AlibabaProviderTests {
             let provider = createAlibaba(settings: .init(videoBaseURL: base, apiKey: "test-key", fetch: fetch))
             let model = provider.video(modelId: AlibabaVideoModelId.wan26T2v)
             let providerOptions: SharedV3ProviderOptions = [
-                "alibaba": ["pollIntervalMs": .number(1), "pollTimeoutMs": .number(1_000)]
+                "alibaba": ["pollIntervalMs": .number(1)]
             ]
             _ = try await model.doGenerate(options: .init(
                 prompt: "p",


### PR DESCRIPTION
## Summary
- remove the unrelated 1-second polling timeout from the Alibaba video base URL test
- keep the production polling interval and timeout behavior unchanged
- prevent scheduler starvation under the full parallel coverage suite from failing a URL-only assertion

## Validation
- `AGENT=1 swift test --enable-code-coverage --parallel --filter videoBaseURLDefaultAndCustom`
- `AGENT=1 swift test --enable-code-coverage --parallel` (4158 tests, 473 suites)
- `git diff --check`