### PR TITLE
feat(google): adopt multimodal function response parts from upstream

### DIFF
--- a/Sources/GoogleProvider/ConvertToGoogleGenerativeAIMessages.swift
+++ b/Sources/GoogleProvider/ConvertToGoogleGenerativeAIMessages.swift
@@ -5,10 +5,19 @@ import AISDKProviderUtils
 public struct GoogleGenerativeAIMessagesOptions: Sendable, Equatable {
     public var isGemmaModel: Bool
     public var providerOptionsName: String
+    public var supportsFunctionResponseParts: Bool
+    public var includeFunctionCallIds: Bool
 
-    public init(isGemmaModel: Bool = false, providerOptionsName: String = "google") {
+    public init(
+        isGemmaModel: Bool = false,
+        providerOptionsName: String = "google",
+        supportsFunctionResponseParts: Bool = true,
+        includeFunctionCallIds: Bool = true
+    ) {
         self.isGemmaModel = isGemmaModel
         self.providerOptionsName = providerOptionsName
+        self.supportsFunctionResponseParts = supportsFunctionResponseParts
+        self.includeFunctionCallIds = includeFunctionCallIds
     }
 }
 
@@ -117,6 +126,7 @@ func convertToGoogleGenerativeAIMessages(
                 case .toolCall(let toolCall):
                     return .functionCall(
                         .init(
+                            id: options.includeFunctionCallIds ? toolCall.toolCallId : nil,
                             name: toolCall.toolName,
                             arguments: toolCall.input,
                             thoughtSignature: googleThoughtSignature(
@@ -146,22 +156,22 @@ func convertToGoogleGenerativeAIMessages(
 
                 switch toolResult.output {
                 case .content(let value, _):
-                    for contentPart in value {
-                        switch contentPart {
-                        case .text(let text):
-                            let response = JSONValue.object([
-                                "name": .string(toolResult.toolName),
-                                "content": .string(text)
-                            ])
-                            converted.append(.functionResponse(.init(name: toolResult.toolName, response: response)))
-                        case .media(let data, let mediaType):
-                            converted.append(.inlineData(.init(mimeType: mediaType, data: data)))
-                            converted.append(.text(.init(text: "Tool executed successfully and returned this image as a response")))
-                        @unknown default:
-                            // Fallback for future enum cases mirrors upstream JSON.stringify behaviour
-                            let jsonString = stringifyToolResultContentPart(contentPart)
-                            converted.append(.text(.init(text: jsonString)))
-                        }
+                    if options.supportsFunctionResponseParts {
+                        appendToolResultParts(
+                            into: &converted,
+                            toolName: toolResult.toolName,
+                            toolCallId: toolResult.toolCallId,
+                            includeFunctionCallIds: options.includeFunctionCallIds,
+                            contentParts: value
+                        )
+                    } else {
+                        appendLegacyToolResultParts(
+                            into: &converted,
+                            toolName: toolResult.toolName,
+                            toolCallId: toolResult.toolCallId,
+                            includeFunctionCallIds: options.includeFunctionCallIds,
+                            contentParts: value
+                        )
                     }
 
                 case .text(let value, _):
@@ -169,35 +179,55 @@ func convertToGoogleGenerativeAIMessages(
                         "name": .string(toolResult.toolName),
                         "content": .string(value)
                     ])
-                    converted.append(.functionResponse(.init(name: toolResult.toolName, response: response)))
+                    converted.append(.functionResponse(.init(
+                        id: options.includeFunctionCallIds ? toolResult.toolCallId : nil,
+                        name: toolResult.toolName,
+                        response: response
+                    )))
 
                 case .json(let value, _):
                     let response = JSONValue.object([
                         "name": .string(toolResult.toolName),
                         "content": value
                     ])
-                    converted.append(.functionResponse(.init(name: toolResult.toolName, response: response)))
+                    converted.append(.functionResponse(.init(
+                        id: options.includeFunctionCallIds ? toolResult.toolCallId : nil,
+                        name: toolResult.toolName,
+                        response: response
+                    )))
 
                 case .executionDenied(let reason, _):
                     let response = JSONValue.object([
                         "name": .string(toolResult.toolName),
                         "content": .string(reason ?? "Tool execution denied.")
                     ])
-                    converted.append(.functionResponse(.init(name: toolResult.toolName, response: response)))
+                    converted.append(.functionResponse(.init(
+                        id: options.includeFunctionCallIds ? toolResult.toolCallId : nil,
+                        name: toolResult.toolName,
+                        response: response
+                    )))
 
                 case .errorText(let value, _):
                     let response = JSONValue.object([
                         "name": .string(toolResult.toolName),
                         "content": .string(value)
                     ])
-                    converted.append(.functionResponse(.init(name: toolResult.toolName, response: response)))
+                    converted.append(.functionResponse(.init(
+                        id: options.includeFunctionCallIds ? toolResult.toolCallId : nil,
+                        name: toolResult.toolName,
+                        response: response
+                    )))
 
                 case .errorJson(let value, _):
                     let response = JSONValue.object([
                         "name": .string(toolResult.toolName),
                         "content": value
                     ])
-                    converted.append(.functionResponse(.init(name: toolResult.toolName, response: response)))
+                    converted.append(.functionResponse(.init(
+                        id: options.includeFunctionCallIds ? toolResult.toolCallId : nil,
+                        name: toolResult.toolName,
+                        response: response
+                    )))
                 }
             }
 
@@ -238,6 +268,68 @@ private func googleThoughtSignature(
         return nil
     }
     return signature
+}
+
+private func appendToolResultParts(
+    into parts: inout [GoogleGenerativeAIContentPart],
+    toolName: String,
+    toolCallId: String?,
+    includeFunctionCallIds: Bool,
+    contentParts: [LanguageModelV3ToolResultContentPart]
+) {
+    var functionResponseParts: [GoogleFunctionResponsePart] = []
+    var responseTextParts: [String] = []
+
+    for contentPart in contentParts {
+        switch contentPart {
+        case .text(let text):
+            responseTextParts.append(text)
+        case .media(let data, let mediaType):
+            functionResponseParts.append(.init(
+                inlineData: .init(mimeType: mediaType, data: data)
+            ))
+        }
+    }
+
+    let contentText = responseTextParts.isEmpty ? "Tool executed successfully." : responseTextParts.joined(separator: "\n")
+    let response = JSONValue.object([
+        "name": .string(toolName),
+        "content": .string(contentText)
+    ])
+    parts.append(.functionResponse(.init(
+        id: includeFunctionCallIds ? toolCallId : nil,
+        name: toolName,
+        response: response,
+        parts: functionResponseParts.isEmpty ? nil : functionResponseParts
+    )))
+}
+
+private func appendLegacyToolResultParts(
+    into parts: inout [GoogleGenerativeAIContentPart],
+    toolName: String,
+    toolCallId: String?,
+    includeFunctionCallIds: Bool,
+    contentParts: [LanguageModelV3ToolResultContentPart]
+) {
+    for contentPart in contentParts {
+        switch contentPart {
+        case .text(let text):
+            let response = JSONValue.object([
+                "name": .string(toolName),
+                "content": .string(text)
+            ])
+            parts.append(.functionResponse(.init(
+                id: includeFunctionCallIds ? toolCallId : nil,
+                name: toolName,
+                response: response
+            )))
+        case .media(let data, let mediaType):
+            let topLevel = getTopLevelMediaType(mediaType)
+            let noun = topLevel == "image" ? "image" : "file"
+            parts.append(.inlineData(.init(mimeType: mediaType, data: data)))
+            parts.append(.text(.init(text: "Tool executed successfully and returned this \(noun) as a response")))
+        }
+    }
 }
 
 private func stringifyToolResultContentPart(_ part: LanguageModelV3ToolResultContentPart) -> String {

--- a/Sources/GoogleProvider/GoogleGenerativeAILanguageModel.swift
+++ b/Sources/GoogleProvider/GoogleGenerativeAILanguageModel.swift
@@ -1048,18 +1048,36 @@ private func encodePrompt(_ prompt: GoogleGenerativeAIPrompt) throws -> (systemI
                     "name": .string(call.name)
                 ]
                 inner["args"] = call.arguments
+                if let id = call.id {
+                    inner["id"] = .string(id)
+                }
                 var object: [String: JSONValue] = ["functionCall": .object(inner)]
                 if let signature = call.thoughtSignature {
                     object["thoughtSignature"] = .string(signature)
                 }
                 return .object(object)
             case .functionResponse(let response):
-                let responseObject = JSONValue.object([
+                var inner: [String: JSONValue] = [
                     "name": .string(response.name),
                     "response": response.response
-                ])
+                ]
+                if let id = response.id {
+                    inner["id"] = .string(id)
+                }
+                if let parts = response.parts, !parts.isEmpty {
+                    inner["parts"] = .array(parts.map { part in
+                        var obj: [String: JSONValue] = [
+                            "mimeType": .string(part.inlineData.mimeType),
+                            "data": .string(part.inlineData.data)
+                        ]
+                        if let sig = part.inlineData.thoughtSignature {
+                            obj["thoughtSignature"] = .string(sig)
+                        }
+                        return .object(["inlineData": .object(obj)])
+                    })
+                }
                 return .object([
-                    "functionResponse": responseObject
+                    "functionResponse": .object(inner)
                 ])
             case .fileData(let file):
                 return .object([

--- a/Sources/GoogleProvider/GoogleGenerativeAIPrompt.swift
+++ b/Sources/GoogleProvider/GoogleGenerativeAIPrompt.swift
@@ -75,24 +75,47 @@ public struct GoogleGenerativeAIInlineDataPart: Sendable, Equatable {
 }
 
 public struct GoogleGenerativeAIFunctionCallPart: Sendable, Equatable {
+    public var id: String?
     public var name: String
     public var arguments: JSONValue
     public var thoughtSignature: String?
 
-    public init(name: String, arguments: JSONValue, thoughtSignature: String? = nil) {
+    public init(id: String? = nil, name: String, arguments: JSONValue, thoughtSignature: String? = nil) {
+        self.id = id
         self.name = name
         self.arguments = arguments
         self.thoughtSignature = thoughtSignature
     }
 }
 
+public struct GoogleFunctionResponsePart: Sendable, Equatable {
+    public var inlineData: GoogleGenerativeAIInlineDataPart
+
+    public init(inlineData: GoogleGenerativeAIInlineDataPart) {
+        self.inlineData = inlineData
+    }
+
+    public init(mimeType: String, data: String, thoughtSignature: String? = nil) {
+        self.inlineData = GoogleGenerativeAIInlineDataPart(mimeType: mimeType, data: data, thoughtSignature: thoughtSignature)
+    }
+}
+
 public struct GoogleGenerativeAIFunctionResponsePart: Sendable, Equatable {
+    public var id: String?
     public var name: String
     public var response: JSONValue
+    public var parts: [GoogleFunctionResponsePart]?
 
-    public init(name: String, response: JSONValue) {
+    public init(
+        id: String? = nil,
+        name: String,
+        response: JSONValue,
+        parts: [GoogleFunctionResponsePart]? = nil
+    ) {
+        self.id = id
         self.name = name
         self.response = response
+        self.parts = parts
     }
 }
 

--- a/Tests/GoogleProviderTests/ConvertToGoogleGenerativeAIMessagesTests.swift
+++ b/Tests/GoogleProviderTests/ConvertToGoogleGenerativeAIMessagesTests.swift
@@ -353,8 +353,8 @@ struct ConvertToGoogleGenerativeAIMessagesTests {
         }
     }
 
-    @Test("should convert tool result messages with content type (multipart with images)")
-    func convertToolResultMessagesWithContentTypeMultipartWithImages() throws {
+    @Test("should convert tool result content with image-data into functionResponse parts")
+    func convertToolResultContentWithImageDataIntoFunctionResponseParts() throws {
         let toolPart = LanguageModelV3ToolResultPart(
             toolCallId: "testCallId",
             toolName: "imageGenerator",
@@ -374,10 +374,58 @@ struct ConvertToGoogleGenerativeAIMessagesTests {
             return
         }
 
+        #expect(userParts.count == 1)
+
+        if case let .functionResponse(response) = userParts[0] {
+            #expect(response.id == "testCallId")
+            #expect(response.name == "imageGenerator")
+            guard case let .object(payload) = response.response else {
+                Issue.record("Expected object payload")
+                return
+            }
+            #expect(payload["name"] == .string("imageGenerator"))
+            #expect(payload["content"] == .string("Here is the generated image:"))
+
+            guard let responseParts = response.parts, responseParts.count == 1 else {
+                Issue.record("Expected 1 function response part")
+                return
+            }
+            #expect(responseParts[0].inlineData.mimeType == "image/jpeg")
+            #expect(responseParts[0].inlineData.data == "base64encodedimagedata")
+        } else {
+            Issue.record("Expected function response part")
+        }
+    }
+
+    @Test("should use legacy tool-result conversion when functionResponse parts are unsupported")
+    func legacyToolResultConversionWhenFunctionResponsePartsUnsupported() throws {
+        let toolPart = LanguageModelV3ToolResultPart(
+            toolCallId: "testCallId",
+            toolName: "imageGenerator",
+            output: .content(value: [
+                .text(text: "Here is the generated image:"),
+                .media(data: "base64encodedimagedata", mediaType: "image/jpeg")
+            ]),
+            providerOptions: nil
+        )
+        let prompt: LanguageModelV3Prompt = [
+            .tool(content: [.toolResult(toolPart)], providerOptions: nil)
+        ]
+
+        let result = try convertToGoogleGenerativeAIMessages(
+            prompt,
+            options: GoogleGenerativeAIMessagesOptions(supportsFunctionResponseParts: false)
+        )
+        guard let userParts = result.contents.first?.parts else {
+            Issue.record("Missing user parts")
+            return
+        }
+
         #expect(userParts.count == 3)
 
         // First part: function response
         if case let .functionResponse(response) = userParts[0] {
+            #expect(response.id == "testCallId")
             #expect(response.name == "imageGenerator")
             guard case let .object(payload) = response.response else {
                 Issue.record("Expected object payload")


### PR DESCRIPTION
Adopts upstream Vercel AI SDK's handling for multimodal tool result content parts in the Google provider. Previously, media content returned by tools was serialized as sibling `inlineData` and `text` parts alongside `functionResponse` within the same user turn, causing Gemini 3+ and Vertex AI to reject tool continuations with HTTP 400. This change aligns with `@ai-sdk/google` by embedding multimodal parts directly into `functionResponse.parts` (with legacy fallback support when disabled).

### Changes

- **Multimodal tool results placed in function response parts.** Before: tool result media was appended as top-level `inlineData` and `text` sibling parts in the user turn (`user: [functionResponse, inlineData, text]`). After: media is nested inside `functionResponse.parts` (`user: [functionResponse(parts: [inlineData])]`), matching the Gemini 3+ specification and upstream `@ai-sdk/google`.
- **Legacy conversion preserved.** Added `supportsFunctionResponseParts` (defaults to `true`) and `includeFunctionCallIds` (defaults to `true`) on `GoogleGenerativeAIMessagesOptions` to preserve pre-Gemini 3 legacy serialization when explicitly requested.
- **Prompt wire encoding updated.** `GoogleGenerativeAILanguageModel.encodePrompt` now serializes `parts` and `id` on `functionResponse`, and `id` on `functionCall`.

### Notes

- **API Compatibility:** Fully backward-compatible. Added optional `parts` and `id` properties with default `nil` values to `GoogleGenerativeAIFunctionResponsePart`.
- **Tests:** Updated `GoogleProviderTests` to verify both modern nested `functionResponse.parts` and legacy fallback formats. All 240 `GoogleProviderTests` and 82 `GoogleVertexProviderTests` pass.